### PR TITLE
Switch to writing private keys in PEM format

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ Manually add the new DID to the header of your plugin. The `did:plc:` prefix mus
 Most subsequent commands after creating a DID require a signing key. There are two ways to provide one:
 
 1. **Key file**: Use `--signing-file` to specify a key file. The file can be either:
-   - A JSON file containing your keys (use `--signing-key` to select a specific key; defaults to first key)
-   - A plain text file containing a multibase base58btc encoded private key (starts with 'z3vL' for rotation keys or 'z3u2' for verification keys)
+   - A JSON file created by fair-tools containing your keys (use `--signing-key` to select a specific key; defaults to first key)
+   - A standalone PEM file (starts with `-----BEGIN EC PRIVATE KEY-----` for rotation keys or `-----BEGIN PRIVATE KEY-----` for verification keys)
+   - A standalone multibase base58btc file (starts with `z3vL` for rotation keys or `zru`/`zrv` for verification keys from FAIR Beacon)
+   - A standalone hex file (64-character lowercase hex string representing the 32-byte private key)
 
 2. **Environment variable**: If `--signing-file` is not provided, the command falls back to an environment variable:
    - `FAIR_VERIFICATION_KEY` for metadata signing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,18 +13,16 @@ Verification keys are implemented with EdDSA using Ed25519. The FAIR protocol sp
 Ed25519 was chosen for interoperability with PHP:
 
 1. FAIR originated as a protocol to be used within the WordPress ecosystem, which uses PHP. The Sodium extension and the sodium_compat library -- both widely used within the WordPress and PHP ecosystems -- [provide Ed25519 as the only algorithm for public key cryptography](https://github.com/paragonie/sodium_compat/issues/46).
-2. The FAIR plugin for WordPress uses Ed25519 for verifying signatures for the same reason, and interoperability with the FAIR plugin and with WordPress is a key requirement of this package.
+2. The FAIR plugin for WordPress uses Ed25519 for verifying signatures for the same reason, and interoperability with existing FAIR tooling for WordPress is a key requirement of this package.
 
 ### Private key storage
 
-Private keys are stored as multibase base58btc strings:
+Private keys are stored in PEM format, which enables detection by secret scanning services and tools:
 
-| Key Type     | Algorithm | Multicodec | Prefix |
-|--------------|-----------|------------|--------|
-| Rotation     | secp256k1 | `0x1301`   | `z3vL` |
-| Verification | ed25519   | `0x1300`   | `z3u2` |
-
-The deterministic prefixes _could_ enable pattern-based secret scanning via custom patterns, although this format is not currently supported by GitHub Secret Scanning by default. This private key storage format is not widespread despite making use of the W3C multibase format. This storage format may be revised in a future version, for example to use PEM headers while retaining support for multibase base58btc for interoperability with existing tools such as the FAIR Beacon plugin for WordPress.
+| Key Type     | Algorithm | PEM Format | Header                           |
+|--------------|-----------|------------|----------------------------------|
+| Rotation     | secp256k1 | SEC1       | `-----BEGIN EC PRIVATE KEY-----` |
+| Verification | ed25519   | PKCS#8     | `-----BEGIN PRIVATE KEY-----`    |
 
 Key files are written with mode `0600` (owner read/write only).
 

--- a/src/cli/did-rotation-key-add.js
+++ b/src/cli/did-rotation-key-add.js
@@ -45,7 +45,7 @@ ${rotationKeyHelp()}
 
 Optional:
   -o, --output-file <file>    Write new key to this file instead of --signing-file
-                              If file exists, appends to rotationKeys. Otherwise writes multibase.
+                              If file exists, appends to rotationKeys. Otherwise writes PEM.
   -h, --help                  Show this help message
 
 The new rotation key will be appended to --signing-file unless --output-file is specified.`);

--- a/src/cli/did-verification-key-add.js
+++ b/src/cli/did-verification-key-add.js
@@ -45,7 +45,7 @@ ${rotationKeyHelp()}
 
 Optional:
   -o, --output-file <file>    Write new key to this file instead of --signing-file
-                              If file exists, appends to verificationKeys. Otherwise writes multibase.
+                              If file exists, appends to verificationKeys. Otherwise writes PEM.
   -h, --help                  Show this help message
 
 The new verification key will be appended to --signing-file unless --output-file is specified.`);

--- a/src/cli/lib/help.js
+++ b/src/cli/lib/help.js
@@ -10,7 +10,7 @@
  */
 export function rotationKeyHelp({ signingKeyDefault = 'first' } = {}) {
 	return `Signing key:
-  -f, --signing-file <file>  Path to key file (JSON with rotationKeys, or multibase)
+  -f, --signing-file <file>  Path to key file (JSON with rotationKeys, or PEM)
   -k, --signing-key <key>    Which rotation key to sign with (default: ${signingKeyDefault}, JSON only)
 
   If --signing-file is not provided, uses FAIR_ROTATION_KEY environment variable.`;
@@ -23,7 +23,7 @@ export function rotationKeyHelp({ signingKeyDefault = 'first' } = {}) {
  */
 export function verificationKeyHelp() {
 	return `Signing key:
-  -f, --signing-file <file>  Path to key file (JSON with verificationKeys, or multibase)
+  -f, --signing-file <file>  Path to key file (JSON with verificationKeys, or PEM)
   -k, --signing-key <key>    Which verification key to sign with (default: first, JSON only)
 
   If --signing-file is not provided, uses FAIR_VERIFICATION_KEY environment variable.`;

--- a/src/cli/lib/signing.js
+++ b/src/cli/lib/signing.js
@@ -16,7 +16,7 @@ export class SigningKeyError extends Error {
 }
 
 /**
- * Decode a multibase base58btc private key string.
+ * Decode a multibase base58btc rotation private key string (32-byte key).
  *
  * @param {string} key - The multibase key (starts with 'z3vL' or 'z3u2')
  * @returns {{prefixHex: string, rawKey: Uint8Array}} - The decoded prefix (hex) and raw key
@@ -45,7 +45,10 @@ function decodeMultibasePrivateKey(key) {
 }
 
 /**
- * Try to parse content as a multibase base58btc rotation private key.
+ * Decode a multibase base58btc verification private key string (Sodium 64-byte format).
+ *
+ * Sodium stores Ed25519 secret keys as 64 bytes: the 32-byte seed concatenated with
+ * the 32-byte public key. This function extracts just the 32-byte seed.
  *
  * @param {string} content - The file content to check
  * @returns {string|null} - The hex key if valid multibase, null otherwise
@@ -71,7 +74,7 @@ function parseAsMultibaseRotationKey(content) {
 }
 
 /**
- * Try to parse content as a multibase base58btc verification private key.
+ * Decode a PEM-encoded EC private key (SEC1 format) to raw bytes.
  *
  * @param {string} content - The file content to check
  * @returns {string|null} - The hex key if valid multibase, null otherwise
@@ -97,11 +100,11 @@ function parseAsMultibaseVerificationKey(content) {
 }
 
 /**
- * Parse a rotation key value from JSON (could be multibase or hex for backwards compatibility).
+ * Check if content looks like a PEM-encoded EC private key (rotation key).
  *
- * @param {string} value - The key value from JSON
+ * @param {string} content - The content to check
  * @returns {string} - The hex key
- * @throws {SigningKeyError} If the value is invalid
+ * @throws {SigningKeyError} If the format is invalid or unrecognized
  */
 function parseRotationKeyValue(value) {
 	const multibaseKey = parseAsMultibaseRotationKey(value);
@@ -113,11 +116,11 @@ function parseRotationKeyValue(value) {
 }
 
 /**
- * Parse a verification key value from JSON (could be multibase or hex for backwards compatibility).
+ * Parse content as a verification private key (PEM, multibase, or hex).
  *
- * @param {string} value - The key value from JSON
+ * @param {string} content - The file content to parse
  * @returns {string} - The hex key
- * @throws {SigningKeyError} If the value is invalid
+ * @throws {SigningKeyError} If the format is invalid or unrecognized
  */
 function parseVerificationKeyValue(value) {
 	const multibaseKey = parseAsMultibaseVerificationKey(value);
@@ -131,13 +134,15 @@ function parseVerificationKeyValue(value) {
 /**
  * Load a rotation key from a key file or environment variable.
  *
- * The key file can be either:
- * - A multibase base58btc encoded private key (starts with 'z3vL')
- * - A JSON file with a `rotationKeys` object mapping public keys to private keys
+ * The key file can contain one of:
+ * - A single PEM-encoded EC private key (-----BEGIN EC PRIVATE KEY-----)
+ * - A single multibase base58btc encoded private key (starts with 'z3vL')
+ * - A single 64-character hex string (32-byte private key)
+ * - A JSON-encoded string containing a `rotationKeys` object mapping public keys to private keys
  *
  * @param {{
  *   signingFile?: string,
- *   signingKey?: string, // ignored for multibase files
+ *   signingKey?: string, // ignored for standalone key files
  *   envVar?: string // defaults to 'FAIR_ROTATION_KEY'
  * }} opts
  * @returns {Promise<{privateKeyHex: string, keyData: object|null}>}
@@ -160,7 +165,7 @@ export async function loadRotationKey({ signingFile, signingKey, envVar = 'FAIR_
 		const multibaseKey = parseAsMultibaseRotationKey(keyContent);
 		if (multibaseKey) {
 			if (signingKey) {
-				throw new SigningKeyError('Cannot specify a signing key when using a multibase key file');
+				throw new SigningKeyError('Cannot specify a signing key when using a standalone key file');
 			}
 			return { privateKeyHex: multibaseKey, keyData: null };
 		}
@@ -170,7 +175,7 @@ export async function loadRotationKey({ signingFile, signingKey, envVar = 'FAIR_
 		try {
 			keyData = JSON.parse(keyContent);
 		} catch {
-			throw new SigningKeyError('Key file must be valid JSON or a multibase base58btc encoded rotation key (starting with "z3vL")');
+			throw new SigningKeyError('Key file must be valid JSON or a standalone key (PEM, multibase, or hex)');
 		}
 
 		const rotationKeys = keyData.rotationKeys || {};
@@ -205,13 +210,15 @@ export async function loadRotationKey({ signingFile, signingKey, envVar = 'FAIR_
 /**
  * Load a verification key from a key file or environment variable.
  *
- * The key file can be either:
- * - A multibase base58btc encoded private key (starts with 'z3u2')
- * - A JSON file with a `verificationKeys` object mapping public keys to private keys
+ * The key file can contain one of:
+ * - A single PEM-encoded PKCS#8 private key (-----BEGIN PRIVATE KEY-----)
+ * - A single multibase base58btc encoded private key (starts with 'zru' or 'zrv')
+ * - A single 64-character hex string (32-byte private key)
+ * - A JSON-encoded string containing a `verificationKeys` object mapping public keys to private keys
  *
  * @param {{
  *   signingFile?: string,
- *   signingKey?: string, // ignored for multibase files
+ *   signingKey?: string, // ignored for standalone key files
  *   envVar?: string // defaults to 'FAIR_VERIFICATION_KEY'
  * }} opts
  * @returns {Promise<{privateKeyHex: string, keyData: object|null}>}
@@ -234,7 +241,7 @@ export async function loadVerificationKey({ signingFile, signingKey, envVar = 'F
 		const multibaseKey = parseAsMultibaseVerificationKey(keyContent);
 		if (multibaseKey) {
 			if (signingKey) {
-				throw new SigningKeyError('Cannot specify a signing key when using a multibase key file');
+				throw new SigningKeyError('Cannot specify a signing key when using a standalone key file');
 			}
 			return { privateKeyHex: multibaseKey, keyData: null };
 		}
@@ -244,7 +251,7 @@ export async function loadVerificationKey({ signingFile, signingKey, envVar = 'F
 		try {
 			keyData = JSON.parse(keyContent);
 		} catch {
-			throw new SigningKeyError('Key file must be valid JSON or a multibase base58btc encoded verification key (starting with "z3u2")');
+			throw new SigningKeyError('Key file must be valid JSON or a standalone key (PEM, multibase, or hex)');
 		}
 
 		const verificationKeys = keyData.verificationKeys || {};
@@ -280,13 +287,15 @@ export async function loadVerificationKey({ signingFile, signingKey, envVar = 'F
  * Load a rotation key for revoking another rotation key.
  * Auto-selects a key that isn't the one being revoked (for JSON files only).
  *
- * The key file can be either:
- * - A multibase base58btc encoded private key (starts with 'z3vL')
- * - A JSON file with a `rotationKeys` object mapping public keys to private keys
+ * The key file can contain one of:
+ * - A single PEM-encoded EC private key (-----BEGIN EC PRIVATE KEY-----)
+ * - A single multibase base58btc encoded private key (starts with 'z3vL')
+ * - A single 64-character hex string (32-byte private key)
+ * - A JSON-encoded string containing a `rotationKeys` object mapping public keys to private keys
  *
  * @param {{
  *   signingFile?: string,
- *   signingKey?: string, // ignored for multibase files
+ *   signingKey?: string, // ignored for standalone key files
  *   revokeKey: string, // the key being revoked (to avoid using it for signing)
  *   envVar?: string // defaults to 'FAIR_ROTATION_KEY'
  * }} opts
@@ -306,7 +315,7 @@ export async function loadRotationKeyForRevocation({ signingFile, signingKey, re
 		const multibaseKey = parseAsMultibaseRotationKey(keyContent);
 		if (multibaseKey) {
 			if (signingKey) {
-				throw new SigningKeyError('Cannot specify a signing key when using a multibase key file');
+				throw new SigningKeyError('Cannot specify a signing key when using a standalone key file');
 			}
 			return { privateKeyHex: multibaseKey, keyData: null };
 		}
@@ -316,7 +325,7 @@ export async function loadRotationKeyForRevocation({ signingFile, signingKey, re
 		try {
 			keyData = JSON.parse(keyContent);
 		} catch {
-			throw new SigningKeyError('Key file must be valid JSON or a multibase base58btc encoded rotation key (starting with "z3vL")');
+			throw new SigningKeyError('Key file must be valid JSON or a standalone key (PEM, multibase, or hex)');
 		}
 
 		const rotationKeys = keyData.rotationKeys || {};

--- a/src/cli/lib/signing.js
+++ b/src/cli/lib/signing.js
@@ -1,28 +1,42 @@
+import crypto from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { base58btc } from 'multiformats/bases/base58';
-import {
-	SECP256K1_PRIV_PREFIX,
-	ED25519_PRIV_PREFIX,
-} from '../../keyfile.js';
+
+/**
+ * Multicodec prefix for secp256k1 private keys (rotation keys).
+ * Used when reading multibase-encoded keys for interoperability with FAIR Beacon.
+ */
+const SECP256K1_PRIV_PREFIX = new Uint8Array([0x81, 0x26]);
+
+/**
+ * Multicodec prefix for ed25519 private keys (verification keys).
+ * Used when reading multibase-encoded keys for interoperability with FAIR Beacon.
+ */
+const ED25519_PRIV_PREFIX = new Uint8Array([0x80, 0x26]);
 
 const SECP256K1_PRIV_PREFIX_HEX = Buffer.from(SECP256K1_PRIV_PREFIX).toString('hex');
 const ED25519_PRIV_PREFIX_HEX = Buffer.from(ED25519_PRIV_PREFIX).toString('hex');
 
-export class SigningKeyError extends Error {
-	constructor(message) {
-		super(message);
-		this.name = 'SigningKeyError';
-	}
-}
+/**
+ * PEM header for EC private keys (SEC1 format, used for secp256k1 rotation keys).
+ */
+const EC_PRIVATE_KEY_HEADER = '-----BEGIN EC PRIVATE KEY-----';
+
+/**
+ * PEM header for PKCS#8 private keys (used for Ed25519 verification keys).
+ */
+const PKCS8_PRIVATE_KEY_HEADER = '-----BEGIN PRIVATE KEY-----';
+
+export class SigningKeyError extends Error {}
 
 /**
  * Decode a multibase base58btc rotation private key string (32-byte key).
  *
- * @param {string} key - The multibase key (starts with 'z3vL' or 'z3u2')
- * @returns {{prefixHex: string, rawKey: Uint8Array}} - The decoded prefix (hex) and raw key
+ * @param {string} key - The multibase key (starts with 'z3vL')
+ * @returns {Uint8Array} - The 32-byte private key
  * @throws {SigningKeyError} If the key format is invalid
  */
-function decodeMultibasePrivateKey(key) {
+function decodeMultibaseRotationKey(key) {
 	let decoded;
 	try {
 		decoded = base58btc.decode(key);
@@ -35,32 +49,6 @@ function decodeMultibasePrivateKey(key) {
 	}
 
 	const prefixHex = Buffer.from(decoded.slice(0, 2)).toString('hex');
-	const rawKey = decoded.slice(2);
-
-	if (rawKey.length !== 32) {
-		throw new SigningKeyError('Invalid key format. The key has the wrong length.');
-	}
-
-	return { prefixHex, rawKey };
-}
-
-/**
- * Decode a multibase base58btc verification private key string (Sodium 64-byte format).
- *
- * Sodium stores Ed25519 secret keys as 64 bytes: the 32-byte seed concatenated with
- * the 32-byte public key. This function extracts just the 32-byte seed.
- *
- * @param {string} content - The file content to check
- * @returns {string|null} - The hex key if valid multibase, null otherwise
- * @throws {SigningKeyError} If it looks like multibase but is invalid
- */
-function parseAsMultibaseRotationKey(content) {
-	const trimmed = content.trim();
-	if (!trimmed.startsWith('z')) {
-		return null;
-	}
-
-	const { prefixHex, rawKey } = decodeMultibasePrivateKey(trimmed);
 
 	if (prefixHex === ED25519_PRIV_PREFIX_HEX) {
 		throw new SigningKeyError('Wrong key type for this operation. This looks like a verification key, but a rotation key is required.');
@@ -70,23 +58,38 @@ function parseAsMultibaseRotationKey(content) {
 		throw new SigningKeyError(`Unrecognized key type (prefix: ${prefixHex}). Expected a rotation key.`);
 	}
 
-	return Buffer.from(rawKey).toString('hex');
+	const rawKey = decoded.slice(2);
+
+	if (rawKey.length !== 32) {
+		throw new SigningKeyError('Invalid key format. The key has the wrong length.');
+	}
+
+	return rawKey;
 }
 
 /**
- * Decode a PEM-encoded EC private key (SEC1 format) to raw bytes.
+ * Decode a multibase base58btc verification private key string (Sodium 64-byte format).
  *
- * @param {string} content - The file content to check
- * @returns {string|null} - The hex key if valid multibase, null otherwise
- * @throws {SigningKeyError} If it looks like multibase but is invalid
+ * Sodium stores Ed25519 secret keys as 64 bytes: the 32-byte seed concatenated with
+ * the 32-byte public key. This function extracts just the 32-byte seed.
+ *
+ * @param {string} key - The multibase key (starts with 'zru' or 'zrv')
+ * @returns {Uint8Array} - The 32-byte private key seed
+ * @throws {SigningKeyError} If the key format is invalid
  */
-function parseAsMultibaseVerificationKey(content) {
-	const trimmed = content.trim();
-	if (!trimmed.startsWith('z')) {
-		return null;
+function decodeMultibaseVerificationKey(key) {
+	let decoded;
+	try {
+		decoded = base58btc.decode(key);
+	} catch (err) {
+		throw new SigningKeyError('Invalid key format. The key could not be decoded.');
 	}
 
-	const { prefixHex, rawKey } = decodeMultibasePrivateKey(trimmed);
+	if (decoded.length < 2) {
+		throw new SigningKeyError('Invalid key format. The key is too short.');
+	}
+
+	const prefixHex = Buffer.from(decoded.slice(0, 2)).toString('hex');
 
 	if (prefixHex === SECP256K1_PRIV_PREFIX_HEX) {
 		throw new SigningKeyError('Wrong key type for this operation. This looks like a rotation key, but a verification key is required.');
@@ -96,23 +99,149 @@ function parseAsMultibaseVerificationKey(content) {
 		throw new SigningKeyError(`Unrecognized key type (prefix: ${prefixHex}). Expected a verification key.`);
 	}
 
-	return Buffer.from(rawKey).toString('hex');
+	const rawKey = decoded.slice(2);
+
+	// Sodium format: 64 bytes (32-byte seed + 32-byte public key)
+	if (rawKey.length === 64) {
+		return rawKey.slice(0, 32);
+	}
+
+	throw new SigningKeyError('Invalid key format. Expected a 64-byte Sodium-format Ed25519 key.');
+}
+
+/**
+ * Decode a PEM-encoded EC private key (SEC1 format) to raw bytes.
+ *
+ * @param {string} key - The PEM string (-----BEGIN EC PRIVATE KEY-----)
+ * @returns {Uint8Array} - The 32-byte raw private key
+ * @throws {SigningKeyError} If the PEM format is invalid
+ */
+function decodeECPrivateKeyPEM(key) {
+	let keyObject;
+	try {
+		keyObject = crypto.createPrivateKey({
+			key,
+			format: 'pem',
+		});
+	} catch {
+		throw new SigningKeyError('Invalid rotation key. The PEM file could not be parsed.');
+	}
+
+	// Export as JWK to get the raw 'd' parameter (private key)
+	const jwk = keyObject.export({
+		format: 'jwk',
+	});
+	if (!jwk.d) {
+		throw new SigningKeyError('Invalid rotation key. The PEM file is missing private key data.');
+	}
+
+	// JWK 'd' is base64url-encoded
+	const rawKey = Buffer.from(jwk.d, 'base64url');
+	if (rawKey.length !== 32) {
+		throw new SigningKeyError('Invalid rotation key. The key has the wrong length.');
+	}
+
+	return new Uint8Array(rawKey);
+}
+
+/**
+ * Decode a PEM-encoded PKCS#8 private key (Ed25519) to raw bytes.
+ *
+ * @param {string} key - The PEM string (-----BEGIN PRIVATE KEY-----)
+ * @returns {Uint8Array} - The 32-byte raw private key
+ * @throws {SigningKeyError} If the PEM format is invalid
+ */
+function decodePKCS8PrivateKeyPEM(key) {
+	let keyObject;
+	try {
+		keyObject = crypto.createPrivateKey({
+			key,
+			format: 'pem',
+		});
+	} catch {
+		throw new SigningKeyError('Invalid verification key. The PEM file could not be parsed.');
+	}
+
+	// Export as JWK to get the raw 'd' parameter (private key)
+	const jwk = keyObject.export({
+		format: 'jwk',
+	});
+	if (!jwk.d) {
+		throw new SigningKeyError('Invalid verification key. The PEM file is missing private key data.');
+	}
+
+	// JWK 'd' is base64url-encoded
+	const rawKey = Buffer.from(jwk.d, 'base64url');
+	if (rawKey.length !== 32) {
+		throw new SigningKeyError('Invalid verification key. The key has the wrong length.');
+	}
+
+	return new Uint8Array(rawKey);
 }
 
 /**
  * Check if content looks like a PEM-encoded EC private key (rotation key).
  *
  * @param {string} content - The content to check
+ * @returns {boolean}
+ */
+function isECPrivateKeyPEM(content) {
+	return content.startsWith(EC_PRIVATE_KEY_HEADER);
+}
+
+/**
+ * Check if content looks like a PEM-encoded PKCS#8 private key (verification key).
+ *
+ * @param {string} content - The content to check
+ * @returns {boolean}
+ */
+function isPKCS8PrivateKeyPEM(content) {
+	return content.startsWith(PKCS8_PRIVATE_KEY_HEADER);
+}
+
+/**
+ * Check if content looks like a 32-byte hex-encoded private key.
+ *
+ * @param {string} content - The content to check
+ * @returns {boolean}
+ */
+function isHexPrivateKey(content) {
+	return /^[a-f0-9]{64}$/i.test(content);
+}
+
+/**
+ * Parse content as a rotation private key (PEM, multibase, or hex).
+ *
+ * @param {string} content - The file content to parse
  * @returns {string} - The hex key
  * @throws {SigningKeyError} If the format is invalid or unrecognized
  */
-function parseRotationKeyValue(value) {
-	const multibaseKey = parseAsMultibaseRotationKey(value);
-	if (multibaseKey) {
-		return multibaseKey;
+function parseAsRotationKey(content) {
+	const trimmed = content.trim();
+
+	// Try PEM format first (EC PRIVATE KEY for secp256k1)
+	if (isECPrivateKeyPEM(trimmed)) {
+		const rawKey = decodeECPrivateKeyPEM(trimmed);
+		return Buffer.from(rawKey).toString('hex');
 	}
-	// Assume hex for backwards compatibility
-	return value;
+
+	// Check if it's a PKCS#8 PEM (wrong type for rotation key)
+	if (isPKCS8PrivateKeyPEM(trimmed)) {
+		throw new SigningKeyError('Wrong key type for this operation. This looks like a verification key, but a rotation key is required.');
+	}
+
+	// Try multibase format
+	if (trimmed.startsWith('z')) {
+		const rawKey = decodeMultibaseRotationKey(trimmed);
+		return Buffer.from(rawKey).toString('hex');
+	}
+
+	// Try raw hex format
+	if (isHexPrivateKey(trimmed)) {
+		return trimmed.toLowerCase();
+	}
+
+	throw new SigningKeyError('Unrecognized key format. Expected a PEM, multibase, or hex encoded rotation key.');
 }
 
 /**
@@ -122,13 +251,32 @@ function parseRotationKeyValue(value) {
  * @returns {string} - The hex key
  * @throws {SigningKeyError} If the format is invalid or unrecognized
  */
-function parseVerificationKeyValue(value) {
-	const multibaseKey = parseAsMultibaseVerificationKey(value);
-	if (multibaseKey) {
-		return multibaseKey;
+function parseAsVerificationKey(content) {
+	const trimmed = content.trim();
+
+	// Try PEM format first (PKCS#8 for Ed25519)
+	if (isPKCS8PrivateKeyPEM(trimmed)) {
+		const rawKey = decodePKCS8PrivateKeyPEM(trimmed);
+		return Buffer.from(rawKey).toString('hex');
 	}
-	// Assume hex for backwards compatibility
-	return value;
+
+	// Check if it's an EC PEM (wrong type for verification key)
+	if (isECPrivateKeyPEM(trimmed)) {
+		throw new SigningKeyError('Wrong key type for this operation. This looks like a rotation key, but a verification key is required.');
+	}
+
+	// Try multibase format
+	if (trimmed.startsWith('z')) {
+		const rawKey = decodeMultibaseVerificationKey(trimmed);
+		return Buffer.from(rawKey).toString('hex');
+	}
+
+	// Try raw hex format
+	if (isHexPrivateKey(trimmed)) {
+		return trimmed.toLowerCase();
+	}
+
+	throw new SigningKeyError('Unrecognized key format. Expected a PEM, multibase, or hex encoded verification key.');
 }
 
 /**
@@ -161,13 +309,14 @@ export async function loadRotationKey({ signingFile, signingKey, envVar = 'FAIR_
 			throw new SigningKeyError(`Error reading key file: ${err.message}`);
 		}
 
-		// Try multibase first
-		const multibaseKey = parseAsMultibaseRotationKey(keyContent);
-		if (multibaseKey) {
+		// Try PEM, multibase, or hex format first (standalone key file)
+		const trimmed = keyContent.trim();
+		if (trimmed.startsWith('-----BEGIN') || trimmed.startsWith('z') || isHexPrivateKey(trimmed)) {
+			const standaloneKey = parseAsRotationKey(keyContent);
 			if (signingKey) {
 				throw new SigningKeyError('Cannot specify a signing key when using a standalone key file');
 			}
-			return { privateKeyHex: multibaseKey, keyData: null };
+			return { privateKeyHex: standaloneKey, keyData: null };
 		}
 
 		// Try JSON
@@ -191,9 +340,9 @@ export async function loadRotationKey({ signingFile, signingKey, envVar = 'FAIR_
 			if (!rawValue) {
 				throw new SigningKeyError(`Rotation key ${signingKey} not found in key file. Available keys: ${publicKeys.join(', ')}`);
 			}
-			privateKeyHex = parseRotationKeyValue(rawValue);
+			privateKeyHex = parseAsRotationKey(rawValue);
 		} else {
-			privateKeyHex = parseRotationKeyValue(rotationKeys[publicKeys[0]]);
+			privateKeyHex = parseAsRotationKey(rotationKeys[publicKeys[0]]);
 		}
 
 		return { privateKeyHex, keyData };
@@ -212,7 +361,7 @@ export async function loadRotationKey({ signingFile, signingKey, envVar = 'FAIR_
  *
  * The key file can contain one of:
  * - A single PEM-encoded PKCS#8 private key (-----BEGIN PRIVATE KEY-----)
- * - A single multibase base58btc encoded private key (starts with 'zru' or 'zrv')
+ * - A single multibase base58btc encoded private key in Sodium 64-byte format (starts with 'zru' or 'zrv')
  * - A single 64-character hex string (32-byte private key)
  * - A JSON-encoded string containing a `verificationKeys` object mapping public keys to private keys
  *
@@ -237,13 +386,14 @@ export async function loadVerificationKey({ signingFile, signingKey, envVar = 'F
 			throw new SigningKeyError(`Error reading key file: ${err.message}`);
 		}
 
-		// Try multibase first
-		const multibaseKey = parseAsMultibaseVerificationKey(keyContent);
-		if (multibaseKey) {
+		// Try PEM, multibase, or hex format first (standalone key file)
+		const trimmed = keyContent.trim();
+		if (trimmed.startsWith('-----BEGIN') || trimmed.startsWith('z') || isHexPrivateKey(trimmed)) {
+			const standaloneKey = parseAsVerificationKey(keyContent);
 			if (signingKey) {
 				throw new SigningKeyError('Cannot specify a signing key when using a standalone key file');
 			}
-			return { privateKeyHex: multibaseKey, keyData: null };
+			return { privateKeyHex: standaloneKey, keyData: null };
 		}
 
 		// Try JSON
@@ -267,9 +417,9 @@ export async function loadVerificationKey({ signingFile, signingKey, envVar = 'F
 			if (!rawValue) {
 				throw new SigningKeyError(`Verification key ${signingKey} not found in key file. Available keys: ${publicKeys.join(', ')}`);
 			}
-			privateKeyHex = parseVerificationKeyValue(rawValue);
+			privateKeyHex = parseAsVerificationKey(rawValue);
 		} else {
-			privateKeyHex = parseVerificationKeyValue(verificationKeys[publicKeys[0]]);
+			privateKeyHex = parseAsVerificationKey(verificationKeys[publicKeys[0]]);
 		}
 
 		return { privateKeyHex, keyData };
@@ -311,13 +461,14 @@ export async function loadRotationKeyForRevocation({ signingFile, signingKey, re
 			throw new SigningKeyError(`Error reading key file: ${err.message}`);
 		}
 
-		// Try multibase first
-		const multibaseKey = parseAsMultibaseRotationKey(keyContent);
-		if (multibaseKey) {
+		// Try PEM, multibase, or hex format first (standalone key file)
+		const trimmed = keyContent.trim();
+		if (trimmed.startsWith('-----BEGIN') || trimmed.startsWith('z') || isHexPrivateKey(trimmed)) {
+			const standaloneKey = parseAsRotationKey(keyContent);
 			if (signingKey) {
 				throw new SigningKeyError('Cannot specify a signing key when using a standalone key file');
 			}
-			return { privateKeyHex: multibaseKey, keyData: null };
+			return { privateKeyHex: standaloneKey, keyData: null };
 		}
 
 		// Try JSON
@@ -352,7 +503,7 @@ export async function loadRotationKeyForRevocation({ signingFile, signingKey, re
 			}
 		}
 
-		const privateKeyHex = parseRotationKeyValue(rotationKeys[signerPublicKey]);
+		const privateKeyHex = parseAsRotationKey(rotationKeys[signerPublicKey]);
 		return { privateKeyHex, keyData };
 	}
 

--- a/src/keyfile.js
+++ b/src/keyfile.js
@@ -21,19 +21,21 @@ export class SaveKeyError extends Error {
 
 /**
  * Multicodec prefix for secp256k1 private keys (rotation keys).
+ * Used when reading multibase-encoded keys for interoperability with FAIR Beacon.
  */
 export const SECP256K1_PRIV_PREFIX = new Uint8Array([0x81, 0x26]);
 
 /**
  * Multicodec prefix for ed25519 private keys (verification keys).
+ * Used when reading multibase-encoded keys for interoperability with FAIR Beacon.
  */
 export const ED25519_PRIV_PREFIX = new Uint8Array([0x80, 0x26]);
 
 /**
  * Encodes a rotation key (secp256k1) as a multibase base58btc string.
  *
- * @param {Uint8Array} privateKey - The private key bytes
- * @returns {string} The multibase-encoded private key (starts with 'z3vL')
+ * @param {Uint8Array} privateKey - The 32-byte private key
+ * @returns {string} The PEM-encoded private key (-----BEGIN EC PRIVATE KEY-----)
  */
 export function encodeRotationKey(privateKey) {
 	const combined = new Uint8Array(SECP256K1_PRIV_PREFIX.length + privateKey.length);
@@ -43,10 +45,10 @@ export function encodeRotationKey(privateKey) {
 }
 
 /**
- * Encodes a verification key (ed25519) as a multibase base58btc string.
+ * Encodes a verification key (ed25519) as a PEM string in PKCS#8 format.
  *
- * @param {Uint8Array} privateKey - The private key bytes
- * @returns {string} The multibase-encoded private key (starts with 'z3u2')
+ * @param {Uint8Array} privateKey - The 32-byte private key
+ * @returns {string} The PEM-encoded private key (-----BEGIN PRIVATE KEY-----)
  */
 export function encodeVerificationKey(privateKey) {
 	const combined = new Uint8Array(ED25519_PRIV_PREFIX.length + privateKey.length);
@@ -80,7 +82,9 @@ export function getKeyFilePath(directory, did) {
  * Formats the DID key file content.
  *
  * Keys are stored as objects keyed by public key, with values encoded as
- * multibase base58btc strings with appropriate multicodec prefixes.
+ * PEM strings:
+ * - Rotation keys: SEC1 format (-----BEGIN EC PRIVATE KEY-----)
+ * - Verification keys: PKCS#8 format (-----BEGIN PRIVATE KEY-----)
  *
  * @param {{
  *   did: string, // did:plc:...
@@ -122,7 +126,7 @@ export async function writeKeyFile(path, content) {
  * Save a new rotation key to a file.
  *
  * If the file exists and is valid JSON, appends the key to the rotationKeys object.
- * If the file doesn't exist, writes the multibase-encoded key.
+ * If the file doesn't exist, writes the PEM-encoded key as a standalone file.
  *
  * @param {{
  *   outputFile: string,
@@ -149,7 +153,7 @@ export async function saveRotationKeyToFile({ outputFile, key }) {
 			}
 			throw new SaveKeyError(`Error reading output file: ${err.message}`);
 		}
-		// File doesn't exist - will write multibase key
+		// File doesn't exist - will write PEM key
 	}
 
 	try {
@@ -165,7 +169,7 @@ export async function saveRotationKeyToFile({ outputFile, key }) {
 			await writeFile(outputFile, JSON.stringify(outputData, null, 2) + '\n', { mode: KEY_FILE_MODE });
 			return { appended: true };
 		} else {
-			// File doesn't exist - write multibase key
+			// File doesn't exist - write PEM key with proper multiline format
 			await writeFile(outputFile, encodedKey + '\n', { mode: KEY_FILE_MODE });
 			return { appended: false };
 		}
@@ -181,7 +185,7 @@ export async function saveRotationKeyToFile({ outputFile, key }) {
  * Save a new verification key to a file.
  *
  * If the file exists and is valid JSON, appends the key to the verificationKeys object.
- * If the file doesn't exist, writes the multibase-encoded key.
+ * If the file doesn't exist, writes the PEM-encoded key as a standalone file.
  *
  * @param {{
  *   outputFile: string,
@@ -208,7 +212,7 @@ export async function saveVerificationKeyToFile({ outputFile, key }) {
 			}
 			throw new SaveKeyError(`Error reading output file: ${err.message}`);
 		}
-		// File doesn't exist - will write multibase key
+		// File doesn't exist - will write PEM key
 	}
 
 	try {
@@ -224,7 +228,7 @@ export async function saveVerificationKeyToFile({ outputFile, key }) {
 			await writeFile(outputFile, JSON.stringify(outputData, null, 2) + '\n', { mode: KEY_FILE_MODE });
 			return { appended: true };
 		} else {
-			// File doesn't exist - write multibase key
+			// File doesn't exist - write PEM key with proper multiline format
 			await writeFile(outputFile, encodedKey + '\n', { mode: KEY_FILE_MODE });
 			return { appended: false };
 		}

--- a/src/keyfile.js
+++ b/src/keyfile.js
@@ -5,43 +5,43 @@
  * with secure permissions.
  */
 
+import crypto from 'node:crypto';
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { base58btc } from 'multiformats/bases/base58';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { ed25519 } from '@noble/curves/ed25519';
 
 /**
  * Error thrown when saving a key to a file fails.
  */
-export class SaveKeyError extends Error {
-	constructor(message) {
-		super(message);
-		this.name = 'SaveKeyError';
-	}
-}
+export class SaveKeyError extends Error {}
 
 /**
- * Multicodec prefix for secp256k1 private keys (rotation keys).
- * Used when reading multibase-encoded keys for interoperability with FAIR Beacon.
- */
-export const SECP256K1_PRIV_PREFIX = new Uint8Array([0x81, 0x26]);
-
-/**
- * Multicodec prefix for ed25519 private keys (verification keys).
- * Used when reading multibase-encoded keys for interoperability with FAIR Beacon.
- */
-export const ED25519_PRIV_PREFIX = new Uint8Array([0x80, 0x26]);
-
-/**
- * Encodes a rotation key (secp256k1) as a multibase base58btc string.
+ * Encodes a rotation key (secp256k1) as a PEM string in SEC1 format.
  *
  * @param {Uint8Array} privateKey - The 32-byte private key
  * @returns {string} The PEM-encoded private key (-----BEGIN EC PRIVATE KEY-----)
  */
 export function encodeRotationKey(privateKey) {
-	const combined = new Uint8Array(SECP256K1_PRIV_PREFIX.length + privateKey.length);
-	combined.set(SECP256K1_PRIV_PREFIX);
-	combined.set(privateKey, SECP256K1_PRIV_PREFIX.length);
-	return base58btc.encode(combined);
+	const uncompressedPublicKey = secp256k1.getPublicKey(privateKey, false);
+	const publicKeyX = uncompressedPublicKey.slice(1, 33);
+	const publicKeyY = uncompressedPublicKey.slice(33, 65);
+
+	const keyObject = crypto.createPrivateKey({
+		key: {
+			kty: 'EC',
+			crv: 'secp256k1',
+			d: Buffer.from(privateKey).toString('base64url'),
+			x: Buffer.from(publicKeyX).toString('base64url'),
+			y: Buffer.from(publicKeyY).toString('base64url'),
+		},
+		format: 'jwk',
+	});
+
+	return keyObject.export({
+		type: 'sec1',
+		format: 'pem',
+	}).trim();
 }
 
 /**
@@ -51,10 +51,21 @@ export function encodeRotationKey(privateKey) {
  * @returns {string} The PEM-encoded private key (-----BEGIN PRIVATE KEY-----)
  */
 export function encodeVerificationKey(privateKey) {
-	const combined = new Uint8Array(ED25519_PRIV_PREFIX.length + privateKey.length);
-	combined.set(ED25519_PRIV_PREFIX);
-	combined.set(privateKey, ED25519_PRIV_PREFIX.length);
-	return base58btc.encode(combined);
+	const publicKey = ed25519.getPublicKey(privateKey);
+	const keyObject = crypto.createPrivateKey({
+		key: {
+			kty: 'OKP',
+			crv: 'Ed25519',
+			d: Buffer.from(privateKey).toString('base64url'),
+			x: Buffer.from(publicKey).toString('base64url'),
+		},
+		format: 'jwk',
+	});
+
+	return keyObject.export({
+		type: 'pkcs8',
+		format: 'pem',
+	}).trim();
 }
 
 /**
@@ -140,7 +151,12 @@ export async function writeKeyFile(path, content) {
  */
 export async function saveRotationKeyToFile({ outputFile, key }) {
 	const publicKey = key.publicKey;
-	const encodedKey = encodeRotationKey(key.privateKey);
+	let encodedKey;
+	try {
+		encodedKey = encodeRotationKey(key.privateKey);
+	} catch (err) {
+		throw new SaveKeyError(`Invalid private key: ${err.message}`);
+	}
 	let outputData = null;
 
 	try {
@@ -199,7 +215,12 @@ export async function saveRotationKeyToFile({ outputFile, key }) {
  */
 export async function saveVerificationKeyToFile({ outputFile, key }) {
 	const publicKey = key.publicKey;
-	const encodedKey = encodeVerificationKey(key.privateKey);
+	let encodedKey;
+	try {
+		encodedKey = encodeVerificationKey(key.privateKey);
+	} catch (err) {
+		throw new SaveKeyError(`Invalid private key: ${err.message}`);
+	}
 	let outputData = null;
 
 	try {

--- a/test/cli/signing.test.js
+++ b/test/cli/signing.test.js
@@ -13,21 +13,28 @@ import { base58btc } from 'multiformats/bases/base58';
 import {
 	encodeRotationKey,
 	encodeVerificationKey,
-	SECP256K1_PRIV_PREFIX,
 } from '../../src/keyfile.js';
+
+// Multicodec prefixes for test data generation
+const SECP256K1_PRIV_PREFIX = new Uint8Array([0x81, 0x26]);
 
 const testDir = join(tmpdir(), 'fair-tools-signing-test-' + Date.now());
 
-// Sample key data - 64 character hex keys (32 bytes)
+// Sample key data - PEM-encoded keys
+const sampleRotationKeyBytes1 = Buffer.from('aabbccdd112233445566778899aabbccddeeff00112233445566778899001122', 'hex');
+const sampleRotationKeyBytes2 = Buffer.from('eeff0011223344556677889900112233445566778899aabbccddeeff00112233', 'hex');
+const sampleVerificationKeyBytes1 = Buffer.from('112233445566778899001122334455667788aabbccddeeff0011223344556677', 'hex');
+const sampleVerificationKeyBytes2 = Buffer.from('556677889900112233445566778899001122aabbccddeeff0011223344556677', 'hex');
+
 const sampleKeyFile = {
 	did: 'did:plc:test123',
 	rotationKeys: {
-		'did:key:zQ3shRotation1': 'aabbccdd112233445566778899aabbccddeeff00112233445566778899001122',
-		'did:key:zQ3shRotation2': 'eeff0011223344556677889900112233445566778899aabbccddeeff00112233',
+		'did:key:zQ3shRotation1': encodeRotationKey(sampleRotationKeyBytes1),
+		'did:key:zQ3shRotation2': encodeRotationKey(sampleRotationKeyBytes2),
 	},
 	verificationKeys: {
-		'did:key:z6MkVerification1': '112233445566778899001122334455667788aabbccddeeff0011223344556677',
-		'did:key:z6MkVerification2': '5566778899001122334455667788990011aabbccddeeff00112233445566778899',
+		'did:key:z6MkVerification1': encodeVerificationKey(sampleVerificationKeyBytes1),
+		'did:key:z6MkVerification2': encodeVerificationKey(sampleVerificationKeyBytes2),
 	},
 };
 
@@ -35,9 +42,18 @@ const sampleKeyFile = {
 const sampleHexKey = 'aabbccdd112233445566778899aabbccddeeff00112233445566778899001122';
 const sampleKeyBytes = Buffer.from(sampleHexKey, 'hex');
 
+// Sample PEM keys (encoded from sampleHexKey)
+const samplePemRotationKey = encodeRotationKey(sampleKeyBytes);
+const samplePemVerificationKey = encodeVerificationKey(sampleKeyBytes);
+
 // Sample multibase keys (encoded from sampleHexKey with appropriate prefix)
-const sampleMultibaseRotationKey = encodeRotationKey(sampleKeyBytes);
-const sampleMultibaseVerificationKey = encodeVerificationKey(sampleKeyBytes);
+const sampleMultibaseRotationKey = base58btc.encode(Buffer.concat([SECP256K1_PRIV_PREFIX, sampleKeyBytes]));
+// Sodium format verification key: 64 bytes (32-byte seed + 32-byte public key)
+// The first 32 bytes are sampleHexKey, followed by 32 dummy bytes for the public key portion
+const sodiumPublicKeyPortion = Buffer.alloc(32, 0xff); // dummy public key bytes
+const sampleMultibaseVerificationKey = base58btc.encode(
+	Buffer.concat([Buffer.from([0x80, 0x26]), sampleKeyBytes, sodiumPublicKeyPortion])
+);
 
 describe('signing.js', () => {
 	after(async () => {
@@ -105,7 +121,7 @@ describe('signing.js', () => {
 
 			const result = await loadRotationKey({ signingFile: filePath });
 
-			assert.strictEqual(result.privateKeyHex, 'aabbccdd112233445566778899aabbccddeeff00112233445566778899001122');
+			assert.strictEqual(result.privateKeyHex, sampleRotationKeyBytes1.toString('hex'));
 			assert.deepStrictEqual(result.keyData, sampleKeyFile);
 		});
 
@@ -119,7 +135,7 @@ describe('signing.js', () => {
 				signingKey: 'did:key:zQ3shRotation2',
 			});
 
-			assert.strictEqual(result.privateKeyHex, 'eeff0011223344556677889900112233445566778899aabbccddeeff00112233');
+			assert.strictEqual(result.privateKeyHex, sampleRotationKeyBytes2.toString('hex'));
 		});
 
 		it('loads multibase-encoded rotation key from JSON file', async () => {
@@ -188,7 +204,29 @@ describe('signing.js', () => {
 			assert.strictEqual(result.keyData, null);
 		});
 
-		it('throws when --signing-key used with multibase key file', async () => {
+		it('loads PEM key file without trailing newline', async () => {
+			await mkdir(testDir, { recursive: true });
+			const filePath = join(testDir, 'rotation-pem.txt');
+			await writeFile(filePath, samplePemRotationKey);
+
+			const result = await loadRotationKey({ signingFile: filePath });
+
+			assert.strictEqual(result.privateKeyHex, sampleHexKey);
+			assert.strictEqual(result.keyData, null);
+		});
+
+		it('loads PEM key file with trailing newline', async () => {
+			await mkdir(testDir, { recursive: true });
+			const filePath = join(testDir, 'rotation-pem-newline.txt');
+			await writeFile(filePath, samplePemRotationKey + '\n');
+
+			const result = await loadRotationKey({ signingFile: filePath });
+
+			assert.strictEqual(result.privateKeyHex, sampleHexKey);
+			assert.strictEqual(result.keyData, null);
+		});
+
+		it('throws when --signing-key used with standalone key file', async () => {
 			await mkdir(testDir, { recursive: true });
 			const filePath = join(testDir, 'rotation-multibase-with-key.txt');
 			await writeFile(filePath, sampleMultibaseRotationKey);
@@ -376,7 +414,7 @@ describe('signing.js', () => {
 
 			const result = await loadVerificationKey({ signingFile: filePath });
 
-			assert.strictEqual(result.privateKeyHex, '112233445566778899001122334455667788aabbccddeeff0011223344556677');
+			assert.strictEqual(result.privateKeyHex, sampleVerificationKeyBytes1.toString('hex'));
 		});
 
 		it('loads specific verification key when specified', async () => {
@@ -389,7 +427,7 @@ describe('signing.js', () => {
 				signingKey: 'did:key:z6MkVerification2',
 			});
 
-			assert.strictEqual(result.privateKeyHex, '5566778899001122334455667788990011aabbccddeeff00112233445566778899');
+			assert.strictEqual(result.privateKeyHex, sampleVerificationKeyBytes2.toString('hex'));
 		});
 
 		it('loads multibase-encoded verification key from JSON file', async () => {
@@ -458,7 +496,29 @@ describe('signing.js', () => {
 			assert.strictEqual(result.keyData, null);
 		});
 
-		it('throws when --signing-key used with multibase key file', async () => {
+		it('loads PEM key file without trailing newline', async () => {
+			await mkdir(testDir, { recursive: true });
+			const filePath = join(testDir, 'verification-pem.txt');
+			await writeFile(filePath, samplePemVerificationKey);
+
+			const result = await loadVerificationKey({ signingFile: filePath });
+
+			assert.strictEqual(result.privateKeyHex, sampleHexKey);
+			assert.strictEqual(result.keyData, null);
+		});
+
+		it('loads PEM key file with trailing newline', async () => {
+			await mkdir(testDir, { recursive: true });
+			const filePath = join(testDir, 'verification-pem-newline.txt');
+			await writeFile(filePath, samplePemVerificationKey + '\n');
+
+			const result = await loadVerificationKey({ signingFile: filePath });
+
+			assert.strictEqual(result.privateKeyHex, sampleHexKey);
+			assert.strictEqual(result.keyData, null);
+		});
+
+		it('throws when --signing-key used with standalone key file', async () => {
 			await mkdir(testDir, { recursive: true });
 			const filePath = join(testDir, 'verification-multibase-with-key.txt');
 			await writeFile(filePath, sampleMultibaseVerificationKey);
@@ -623,7 +683,7 @@ describe('signing.js', () => {
 				revokeKey: 'did:key:zQ3shRotation1',
 			});
 
-			assert.strictEqual(result.privateKeyHex, 'eeff0011223344556677889900112233445566778899aabbccddeeff00112233');
+			assert.strictEqual(result.privateKeyHex, sampleRotationKeyBytes2.toString('hex'));
 		});
 
 		it('uses specified signing key when different from revoke key', async () => {
@@ -637,7 +697,7 @@ describe('signing.js', () => {
 				revokeKey: 'did:key:zQ3shRotation1',
 			});
 
-			assert.strictEqual(result.privateKeyHex, 'eeff0011223344556677889900112233445566778899aabbccddeeff00112233');
+			assert.strictEqual(result.privateKeyHex, sampleRotationKeyBytes2.toString('hex'));
 		});
 
 		it('loads multibase key file without trailing newline', async () => {
@@ -668,7 +728,35 @@ describe('signing.js', () => {
 			assert.strictEqual(result.keyData, null);
 		});
 
-		it('throws when --signing-key used with multibase key file', async () => {
+		it('loads PEM key file without trailing newline', async () => {
+			await mkdir(testDir, { recursive: true });
+			const filePath = join(testDir, 'revoke-pem.txt');
+			await writeFile(filePath, samplePemRotationKey);
+
+			const result = await loadRotationKeyForRevocation({
+				signingFile: filePath,
+				revokeKey: 'did:key:zQ3shSomeKey',
+			});
+
+			assert.strictEqual(result.privateKeyHex, sampleHexKey);
+			assert.strictEqual(result.keyData, null);
+		});
+
+		it('loads PEM key file with trailing newline', async () => {
+			await mkdir(testDir, { recursive: true });
+			const filePath = join(testDir, 'revoke-pem-newline.txt');
+			await writeFile(filePath, samplePemRotationKey + '\n');
+
+			const result = await loadRotationKeyForRevocation({
+				signingFile: filePath,
+				revokeKey: 'did:key:zQ3shSomeKey',
+			});
+
+			assert.strictEqual(result.privateKeyHex, sampleHexKey);
+			assert.strictEqual(result.keyData, null);
+		});
+
+		it('throws when --signing-key used with standalone key file', async () => {
 			await mkdir(testDir, { recursive: true });
 			const filePath = join(testDir, 'revoke-multibase-with-key.txt');
 			await writeFile(filePath, sampleMultibaseRotationKey);

--- a/test/cli/signing.test.js
+++ b/test/cli/signing.test.js
@@ -197,13 +197,13 @@ describe('signing.js', () => {
 				loadRotationKey({ signingFile: filePath, signingKey: 'did:key:zQ3sh...' }),
 				(err) => {
 					assert(err instanceof SigningKeyError);
-					assert.strictEqual(err.message, 'Cannot specify a signing key when using a multibase key file');
+					assert.strictEqual(err.message, 'Cannot specify a signing key when using a standalone key file');
 					return true;
 				}
 			);
 		});
 
-		it('throws for invalid file content (not JSON or multibase)', async () => {
+		it('throws for invalid file content (not JSON, PEM, multibase, or hex)', async () => {
 			await mkdir(testDir, { recursive: true });
 			const filePath = join(testDir, 'rotation-invalid.txt');
 			await writeFile(filePath, 'this is not valid');
@@ -212,13 +212,13 @@ describe('signing.js', () => {
 				loadRotationKey({ signingFile: filePath }),
 				(err) => {
 					assert(err instanceof SigningKeyError);
-					assert.strictEqual(err.message, 'Key file must be valid JSON or a multibase base58btc encoded rotation key (starting with "z3vL")');
+					assert.strictEqual(err.message, 'Key file must be valid JSON or a standalone key (PEM, multibase, or hex)');
 					return true;
 				}
 			);
 		});
 
-		it('throws when multibase key has wrong prefix (ed25519 instead of secp256k1)', async () => {
+		it('throws when standalone key has wrong type (verification instead of rotation)', async () => {
 			await mkdir(testDir, { recursive: true });
 			const filePath = join(testDir, 'rotation-wrong-prefix.txt');
 			// Use a verification key (ed25519) where rotation key (secp256k1) is expected
@@ -467,13 +467,13 @@ describe('signing.js', () => {
 				loadVerificationKey({ signingFile: filePath, signingKey: 'did:key:z6Mk...' }),
 				(err) => {
 					assert(err instanceof SigningKeyError);
-					assert.strictEqual(err.message, 'Cannot specify a signing key when using a multibase key file');
+					assert.strictEqual(err.message, 'Cannot specify a signing key when using a standalone key file');
 					return true;
 				}
 			);
 		});
 
-		it('throws for invalid file content (not JSON or multibase)', async () => {
+		it('throws for invalid file content (not JSON, PEM, multibase, or hex)', async () => {
 			await mkdir(testDir, { recursive: true });
 			const filePath = join(testDir, 'verification-invalid.txt');
 			await writeFile(filePath, 'this is not valid');
@@ -482,13 +482,13 @@ describe('signing.js', () => {
 				loadVerificationKey({ signingFile: filePath }),
 				(err) => {
 					assert(err instanceof SigningKeyError);
-					assert.strictEqual(err.message, 'Key file must be valid JSON or a multibase base58btc encoded verification key (starting with "z3u2")');
+					assert.strictEqual(err.message, 'Key file must be valid JSON or a standalone key (PEM, multibase, or hex)');
 					return true;
 				}
 			);
 		});
 
-		it('throws when multibase key has wrong prefix (secp256k1 instead of ed25519)', async () => {
+		it('throws when standalone key has wrong type (rotation instead of verification)', async () => {
 			await mkdir(testDir, { recursive: true });
 			const filePath = join(testDir, 'verification-wrong-prefix.txt');
 			// Use a rotation key (secp256k1) where verification key (ed25519) is expected
@@ -681,13 +681,13 @@ describe('signing.js', () => {
 				}),
 				(err) => {
 					assert(err instanceof SigningKeyError);
-					assert.strictEqual(err.message, 'Cannot specify a signing key when using a multibase key file');
+					assert.strictEqual(err.message, 'Cannot specify a signing key when using a standalone key file');
 					return true;
 				}
 			);
 		});
 
-		it('throws for invalid file content (not JSON or multibase)', async () => {
+		it('throws for invalid file content (not JSON, PEM, multibase, or hex)', async () => {
 			await mkdir(testDir, { recursive: true });
 			const filePath = join(testDir, 'revoke-invalid.txt');
 			await writeFile(filePath, 'this is not valid');
@@ -699,13 +699,13 @@ describe('signing.js', () => {
 				}),
 				(err) => {
 					assert(err instanceof SigningKeyError);
-					assert.strictEqual(err.message, 'Key file must be valid JSON or a multibase base58btc encoded rotation key (starting with "z3vL")');
+					assert.strictEqual(err.message, 'Key file must be valid JSON or a standalone key (PEM, multibase, or hex)');
 					return true;
 				}
 			);
 		});
 
-		it('throws when multibase key has wrong prefix (ed25519 instead of secp256k1)', async () => {
+		it('throws when standalone key has wrong type (verification instead of rotation)', async () => {
 			await mkdir(testDir, { recursive: true });
 			const filePath = join(testDir, 'revoke-wrong-prefix.txt');
 			// Use a verification key (ed25519) where rotation key (secp256k1) is expected

--- a/test/keyfile.test.js
+++ b/test/keyfile.test.js
@@ -1,9 +1,9 @@
 import { describe, it, after, beforeEach } from 'node:test';
 import assert from 'node:assert';
+import crypto from 'node:crypto';
 import { stat, rm, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { base58btc } from 'multiformats/bases/base58';
 import {
 	getKeyFilePath,
 	formatKeyFileContent,
@@ -14,6 +14,10 @@ import {
 	encodeRotationKey,
 	encodeVerificationKey,
 } from '../src/keyfile.js';
+
+// Sample 32-byte private keys for testing
+const sampleRotationKey = new Uint8Array(32).fill(0xaa);
+const sampleVerificationKey = new Uint8Array(32).fill(0xbb);
 
 describe('getKeyFilePath', () => {
 	it('returns path with DID as filename', () => {
@@ -27,11 +31,11 @@ describe('formatKeyFileContent', () => {
 		const did = 'did:plc:test123';
 		const rotationKey = {
 			publicKey: 'did:key:zQ3shRotation',
-			privateKey: new Uint8Array([0x01, 0x02, 0x03, 0x04]),
+			privateKey: sampleRotationKey,
 		};
 		const verificationKey = {
 			publicKey: 'did:key:z6MkVerification',
-			privateKey: new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd]),
+			privateKey: sampleVerificationKey,
 		};
 
 		const content = formatKeyFileContent({ did, rotationKey, verificationKey });
@@ -41,26 +45,20 @@ describe('formatKeyFileContent', () => {
 
 		// Check rotation key is PEM encoded (SEC1 format for secp256k1)
 		const rotationKeyValue = parsed.rotationKeys['did:key:zQ3shRotation'];
-		assert(rotationKeyValue.startsWith('z'), 'Rotation key should be multibase base58btc');
-		const decodedRotation = base58btc.decode(rotationKeyValue);
-		assert.strictEqual(decodedRotation[0], 0x81);
-		assert.strictEqual(decodedRotation[1], 0x26);
-		assert.deepStrictEqual(Array.from(decodedRotation.slice(2)), [0x01, 0x02, 0x03, 0x04]);
+		assert(rotationKeyValue.startsWith('-----BEGIN EC PRIVATE KEY-----'), 'Rotation key should be SEC1 PEM');
+		assert(rotationKeyValue.endsWith('-----END EC PRIVATE KEY-----'), 'Rotation key should end with SEC1 footer');
 
 		// Check verification key is PEM encoded (PKCS#8 format for Ed25519)
 		const verificationKeyValue = parsed.verificationKeys['did:key:z6MkVerification'];
-		assert(verificationKeyValue.startsWith('z'), 'Verification key should be multibase base58btc');
-		const decodedVerification = base58btc.decode(verificationKeyValue);
-		assert.strictEqual(decodedVerification[0], 0x80);
-		assert.strictEqual(decodedVerification[1], 0x26);
-		assert.deepStrictEqual(Array.from(decodedVerification.slice(2)), [0xaa, 0xbb, 0xcc, 0xdd]);
+		assert(verificationKeyValue.startsWith('-----BEGIN PRIVATE KEY-----'), 'Verification key should be PKCS#8 PEM');
+		assert(verificationKeyValue.endsWith('-----END PRIVATE KEY-----'), 'Verification key should end with PKCS#8 footer');
 	});
 
 	it('produces valid JSON', () => {
 		const content = formatKeyFileContent({
 			did: 'did:plc:test',
-			rotationKey: { publicKey: 'pub1', privateKey: new Uint8Array([1]) },
-			verificationKey: { publicKey: 'pub2', privateKey: new Uint8Array([2]) },
+			rotationKey: { publicKey: 'pub1', privateKey: sampleRotationKey },
+			verificationKey: { publicKey: 'pub2', privateKey: sampleVerificationKey },
 		});
 
 		assert.doesNotThrow(() => JSON.parse(content));
@@ -92,8 +90,8 @@ describe('writeKeyFile', () => {
 		const filePath = join(testDir, 'test-json.json');
 		const content = formatKeyFileContent({
 			did: 'did:plc:jsontest',
-			rotationKey: { publicKey: 'rk', privateKey: new Uint8Array([1, 2, 3]) },
-			verificationKey: { publicKey: 'vk', privateKey: new Uint8Array([4, 5, 6]) },
+			rotationKey: { publicKey: 'rk', privateKey: sampleRotationKey },
+			verificationKey: { publicKey: 'vk', privateKey: sampleVerificationKey },
 		});
 
 		await writeKeyFile(filePath, content);
@@ -105,59 +103,67 @@ describe('writeKeyFile', () => {
 });
 
 describe('encodeRotationKey', () => {
-	it('encodes Uint8Array as multibase base58btc with secp256k1-priv prefix', () => {
-		const key = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
-		const encoded = encodeRotationKey(key);
+	it('encodes 32-byte key as SEC1 PEM format', () => {
+		const encoded = encodeRotationKey(sampleRotationKey);
 
-		assert(encoded.startsWith('z'), 'Should start with z (base58btc multibase prefix)');
-		const decoded = base58btc.decode(encoded);
-		assert.strictEqual(decoded[0], 0x81);
-		assert.strictEqual(decoded[1], 0x26);
-		assert.deepStrictEqual(Array.from(decoded.slice(2)), [0x01, 0x02, 0x03, 0x04]);
+		assert(encoded.startsWith('-----BEGIN EC PRIVATE KEY-----'), 'Should start with SEC1 header');
+		assert(encoded.endsWith('-----END EC PRIVATE KEY-----'), 'Should end with SEC1 footer');
 	});
 
-	it('encodes 32-byte key correctly', () => {
-		const key = new Uint8Array(32).fill(0xaa);
-		const encoded = encodeRotationKey(key);
-		const decoded = base58btc.decode(encoded);
+	it('produces a valid PEM that can be parsed by Node.js crypto', () => {
+		const encoded = encodeRotationKey(sampleRotationKey);
 
-		assert.strictEqual(decoded.length, 34); // 2 prefix + 32 key
-		assert.strictEqual(decoded[0], 0x81);
-		assert.strictEqual(decoded[1], 0x26);
+		// Should be able to import the key
+		const keyObject = crypto.createPrivateKey({ key: encoded, format: 'pem' });
+		assert.strictEqual(keyObject.type, 'private');
+		assert.strictEqual(keyObject.asymmetricKeyType, 'ec');
+	});
+
+	it('round-trips through Node.js crypto', () => {
+		const encoded = encodeRotationKey(sampleRotationKey);
+		const keyObject = crypto.createPrivateKey({ key: encoded, format: 'pem' });
+		const jwk = keyObject.export({ format: 'jwk' });
+		const recovered = Buffer.from(jwk.d, 'base64url');
+
+		assert.deepStrictEqual(new Uint8Array(recovered), sampleRotationKey);
 	});
 });
 
 describe('encodeVerificationKey', () => {
-	it('encodes Uint8Array as multibase base58btc with ed25519-priv prefix', () => {
-		const key = new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd]);
-		const encoded = encodeVerificationKey(key);
+	it('encodes 32-byte key as PKCS#8 PEM format', () => {
+		const encoded = encodeVerificationKey(sampleVerificationKey);
 
-		assert(encoded.startsWith('z'), 'Should start with z (base58btc multibase prefix)');
-		const decoded = base58btc.decode(encoded);
-		assert.strictEqual(decoded[0], 0x80);
-		assert.strictEqual(decoded[1], 0x26);
-		assert.deepStrictEqual(Array.from(decoded.slice(2)), [0xaa, 0xbb, 0xcc, 0xdd]);
+		assert(encoded.startsWith('-----BEGIN PRIVATE KEY-----'), 'Should start with PKCS#8 header');
+		assert(encoded.endsWith('-----END PRIVATE KEY-----'), 'Should end with PKCS#8 footer');
 	});
 
-	it('encodes 32-byte key correctly', () => {
-		const key = new Uint8Array(32).fill(0xbb);
-		const encoded = encodeVerificationKey(key);
-		const decoded = base58btc.decode(encoded);
+	it('produces a valid PEM that can be parsed by Node.js crypto', () => {
+		const encoded = encodeVerificationKey(sampleVerificationKey);
 
-		assert.strictEqual(decoded.length, 34); // 2 prefix + 32 key
-		assert.strictEqual(decoded[0], 0x80);
-		assert.strictEqual(decoded[1], 0x26);
+		// Should be able to import the key
+		const keyObject = crypto.createPrivateKey({ key: encoded, format: 'pem' });
+		assert.strictEqual(keyObject.type, 'private');
+		assert.strictEqual(keyObject.asymmetricKeyType, 'ed25519');
+	});
+
+	it('round-trips through Node.js crypto', () => {
+		const encoded = encodeVerificationKey(sampleVerificationKey);
+		const keyObject = crypto.createPrivateKey({ key: encoded, format: 'pem' });
+		const jwk = keyObject.export({ format: 'jwk' });
+		const recovered = Buffer.from(jwk.d, 'base64url');
+
+		assert.deepStrictEqual(new Uint8Array(recovered), sampleVerificationKey);
 	});
 });
 
 describe('saveRotationKeyToFile', () => {
 	const testDir = join(tmpdir(), 'fair-tools-save-rotation-key-test-' + Date.now());
 
-	// Helper to create a mock key object from hex string
-	function mockKey(publicKey, hexPrivateKey) {
+	// Helper to create a mock key object with a 32-byte key
+	function mockKey(publicKey) {
 		return {
 			publicKey,
-			privateKey: Buffer.from(hexPrivateKey, 'hex'),
+			privateKey: sampleRotationKey,
 		};
 	}
 
@@ -169,20 +175,17 @@ describe('saveRotationKeyToFile', () => {
 		await rm(testDir, { recursive: true, force: true });
 	});
 
-	it('writes multibase key when file does not exist', async () => {
-		const outputFile = join(testDir, 'new-key.txt');
+	it('writes PEM key when file does not exist', async () => {
+		const outputFile = join(testDir, 'new-key.pem');
 		const result = await saveRotationKeyToFile({
 			outputFile,
-			key: mockKey('did:key:zQ3shTest', 'aabbccdd'),
+			key: mockKey('did:key:zQ3shTest'),
 		});
 
 		assert.strictEqual(result.appended, false);
 		const content = await readFile(outputFile, 'utf-8');
-		assert(content.trim().startsWith('z'), 'Should write multibase key');
-		// Verify it decodes correctly
-		const decoded = base58btc.decode(content.trim());
-		assert.strictEqual(decoded[0], 0x81);
-		assert.strictEqual(decoded[1], 0x26);
+		assert(content.startsWith('-----BEGIN EC PRIVATE KEY-----'), 'Should start with PEM header');
+		assert(content.endsWith('-----END EC PRIVATE KEY-----\n'), 'Should end with PEM footer and trailing newline');
 	});
 
 	it('appends to rotationKeys when file exists with valid JSON', async () => {
@@ -197,7 +200,7 @@ describe('saveRotationKeyToFile', () => {
 
 		const result = await saveRotationKeyToFile({
 			outputFile,
-			key: mockKey('did:key:zQ3shNew', 'aabbccdd'),
+			key: mockKey('did:key:zQ3shNew'),
 		});
 
 		assert.strictEqual(result.appended, true);
@@ -206,7 +209,8 @@ describe('saveRotationKeyToFile', () => {
 		assert.strictEqual(parsed.rotationKeys['did:key:zQ3shExisting'], '11223344');
 		// New key should be PEM encoded
 		const newKeyValue = parsed.rotationKeys['did:key:zQ3shNew'];
-		assert(newKeyValue.startsWith('z'), 'New key should be multibase encoded');
+		assert(newKeyValue.startsWith('-----BEGIN EC PRIVATE KEY-----'), 'New key should start with PEM header');
+		assert(newKeyValue.endsWith('-----END EC PRIVATE KEY-----'), 'New key should end with PEM footer');
 	});
 
 	it('creates rotationKeys object when missing from existing JSON', async () => {
@@ -218,13 +222,14 @@ describe('saveRotationKeyToFile', () => {
 
 		const result = await saveRotationKeyToFile({
 			outputFile,
-			key: mockKey('did:key:zQ3shNew', 'aabbccdd'),
+			key: mockKey('did:key:zQ3shNew'),
 		});
 
 		assert.strictEqual(result.appended, true);
 		const content = await readFile(outputFile, 'utf-8');
 		const parsed = JSON.parse(content);
-		assert(parsed.rotationKeys['did:key:zQ3shNew'].startsWith('z'));
+		assert(parsed.rotationKeys['did:key:zQ3shNew'].startsWith('-----BEGIN EC PRIVATE KEY-----'), 'Should start with PEM header');
+		assert(parsed.rotationKeys['did:key:zQ3shNew'].endsWith('-----END EC PRIVATE KEY-----'), 'Should end with PEM footer');
 	});
 
 	it('throws SaveKeyError when file exists but is not valid JSON', async () => {
@@ -234,7 +239,7 @@ describe('saveRotationKeyToFile', () => {
 		await assert.rejects(
 			saveRotationKeyToFile({
 				outputFile,
-				key: mockKey('did:key:zQ3shTest', 'aabbccdd'),
+				key: mockKey('did:key:zQ3shTest'),
 			}),
 			(err) => {
 				assert(err instanceof SaveKeyError);
@@ -252,7 +257,7 @@ describe('saveRotationKeyToFile', () => {
 		await assert.rejects(
 			saveRotationKeyToFile({
 				outputFile,
-				key: mockKey('did:key:zQ3shTest', 'aabbccdd'),
+				key: mockKey('did:key:zQ3shTest'),
 			}),
 			(err) => {
 				assert(err instanceof SaveKeyError);
@@ -269,7 +274,7 @@ describe('saveRotationKeyToFile', () => {
 		await assert.rejects(
 			saveRotationKeyToFile({
 				outputFile,
-				key: mockKey('did:key:zQ3shTest', 'aabbccdd'),
+				key: mockKey('did:key:zQ3shTest'),
 			}),
 			(err) => {
 				assert(err instanceof SaveKeyError);
@@ -295,7 +300,7 @@ describe('saveRotationKeyToFile', () => {
 
 		await saveRotationKeyToFile({
 			outputFile,
-			key: mockKey('did:key:zQ3shNew', 'aabbccdd'),
+			key: mockKey('did:key:zQ3shNew'),
 		});
 
 		const content = await readFile(outputFile, 'utf-8');
@@ -303,7 +308,8 @@ describe('saveRotationKeyToFile', () => {
 		assert.strictEqual(parsed.did, 'did:plc:test');
 		assert.strictEqual(parsed.customField, 'should be preserved');
 		assert.strictEqual(parsed.verificationKeys['did:key:z6MkVerify'], '55667788');
-		assert(parsed.rotationKeys['did:key:zQ3shNew'].startsWith('z'));
+		assert(parsed.rotationKeys['did:key:zQ3shNew'].startsWith('-----BEGIN EC PRIVATE KEY-----'), 'Should start with PEM header');
+		assert(parsed.rotationKeys['did:key:zQ3shNew'].endsWith('-----END EC PRIVATE KEY-----'), 'Should end with PEM footer');
 	});
 
 	it('throws SaveKeyError when key already exists in file', async () => {
@@ -319,11 +325,11 @@ describe('saveRotationKeyToFile', () => {
 		await assert.rejects(
 			saveRotationKeyToFile({
 				outputFile,
-				key: mockKey('did:key:zQ3shSame', 'newvalue'),
+				key: mockKey('did:key:zQ3shSame'),
 			}),
 			(err) => {
 				assert(err instanceof SaveKeyError);
-				assert.match(err.message, /Key already exists in file/);
+				assert.strictEqual(err.message, 'Key already exists in file: did:key:zQ3shSame');
 				return true;
 			}
 		);
@@ -333,11 +339,11 @@ describe('saveRotationKeyToFile', () => {
 describe('saveVerificationKeyToFile', () => {
 	const testDir = join(tmpdir(), 'fair-tools-save-verification-key-test-' + Date.now());
 
-	// Helper to create a mock key object from hex string
-	function mockKey(publicKey, hexPrivateKey) {
+	// Helper to create a mock key object with a 32-byte key
+	function mockKey(publicKey) {
 		return {
 			publicKey,
-			privateKey: Buffer.from(hexPrivateKey, 'hex'),
+			privateKey: sampleVerificationKey,
 		};
 	}
 
@@ -349,20 +355,17 @@ describe('saveVerificationKeyToFile', () => {
 		await rm(testDir, { recursive: true, force: true });
 	});
 
-	it('writes multibase key when file does not exist', async () => {
-		const outputFile = join(testDir, 'new-key.txt');
+	it('writes PEM key when file does not exist', async () => {
+		const outputFile = join(testDir, 'new-key.pem');
 		const result = await saveVerificationKeyToFile({
 			outputFile,
-			key: mockKey('did:key:z6MkTest', 'aabbccdd'),
+			key: mockKey('did:key:z6MkTest'),
 		});
 
 		assert.strictEqual(result.appended, false);
 		const content = await readFile(outputFile, 'utf-8');
-		assert(content.trim().startsWith('z'), 'Should write multibase key');
-		// Verify it decodes correctly with ed25519 prefix
-		const decoded = base58btc.decode(content.trim());
-		assert.strictEqual(decoded[0], 0x80);
-		assert.strictEqual(decoded[1], 0x26);
+		assert(content.startsWith('-----BEGIN PRIVATE KEY-----'), 'Should start with PEM header');
+		assert(content.endsWith('-----END PRIVATE KEY-----\n'), 'Should end with PEM footer and trailing newline');
 	});
 
 	it('appends to verificationKeys when file exists with valid JSON', async () => {
@@ -377,7 +380,7 @@ describe('saveVerificationKeyToFile', () => {
 
 		const result = await saveVerificationKeyToFile({
 			outputFile,
-			key: mockKey('did:key:z6MkNew', 'aabbccdd'),
+			key: mockKey('did:key:z6MkNew'),
 		});
 
 		assert.strictEqual(result.appended, true);
@@ -386,7 +389,8 @@ describe('saveVerificationKeyToFile', () => {
 		assert.strictEqual(parsed.verificationKeys['did:key:z6MkExisting'], '11223344');
 		// New key should be PEM encoded
 		const newKeyValue = parsed.verificationKeys['did:key:z6MkNew'];
-		assert(newKeyValue.startsWith('z'), 'New key should be multibase encoded');
+		assert(newKeyValue.startsWith('-----BEGIN PRIVATE KEY-----'), 'New key should start with PEM header');
+		assert(newKeyValue.endsWith('-----END PRIVATE KEY-----'), 'New key should end with PEM footer');
 	});
 
 	it('creates verificationKeys object when missing from existing JSON', async () => {
@@ -398,13 +402,14 @@ describe('saveVerificationKeyToFile', () => {
 
 		const result = await saveVerificationKeyToFile({
 			outputFile,
-			key: mockKey('did:key:z6MkNew', 'aabbccdd'),
+			key: mockKey('did:key:z6MkNew'),
 		});
 
 		assert.strictEqual(result.appended, true);
 		const content = await readFile(outputFile, 'utf-8');
 		const parsed = JSON.parse(content);
-		assert(parsed.verificationKeys['did:key:z6MkNew'].startsWith('z'));
+		assert(parsed.verificationKeys['did:key:z6MkNew'].startsWith('-----BEGIN PRIVATE KEY-----'), 'Should start with PEM header');
+		assert(parsed.verificationKeys['did:key:z6MkNew'].endsWith('-----END PRIVATE KEY-----'), 'Should end with PEM footer');
 	});
 
 	it('throws SaveKeyError when key already exists in file', async () => {
@@ -420,11 +425,11 @@ describe('saveVerificationKeyToFile', () => {
 		await assert.rejects(
 			saveVerificationKeyToFile({
 				outputFile,
-				key: mockKey('did:key:z6MkSame', 'newvalue'),
+				key: mockKey('did:key:z6MkSame'),
 			}),
 			(err) => {
 				assert(err instanceof SaveKeyError);
-				assert.match(err.message, /Key already exists in file/);
+				assert.strictEqual(err.message, 'Key already exists in file: did:key:z6MkSame');
 				return true;
 			}
 		);

--- a/test/keyfile.test.js
+++ b/test/keyfile.test.js
@@ -23,7 +23,7 @@ describe('getKeyFilePath', () => {
 });
 
 describe('formatKeyFileContent', () => {
-	it('formats keys as JSON with multibase-encoded private keys', () => {
+	it('formats keys as JSON with PEM-encoded private keys', () => {
 		const did = 'did:plc:test123';
 		const rotationKey = {
 			publicKey: 'did:key:zQ3shRotation',
@@ -39,7 +39,7 @@ describe('formatKeyFileContent', () => {
 
 		assert.strictEqual(parsed.did, 'did:plc:test123');
 
-		// Check rotation key is multibase encoded with secp256k1-priv prefix (0x8126)
+		// Check rotation key is PEM encoded (SEC1 format for secp256k1)
 		const rotationKeyValue = parsed.rotationKeys['did:key:zQ3shRotation'];
 		assert(rotationKeyValue.startsWith('z'), 'Rotation key should be multibase base58btc');
 		const decodedRotation = base58btc.decode(rotationKeyValue);
@@ -47,7 +47,7 @@ describe('formatKeyFileContent', () => {
 		assert.strictEqual(decodedRotation[1], 0x26);
 		assert.deepStrictEqual(Array.from(decodedRotation.slice(2)), [0x01, 0x02, 0x03, 0x04]);
 
-		// Check verification key is multibase encoded with ed25519-priv prefix (0x8026)
+		// Check verification key is PEM encoded (PKCS#8 format for Ed25519)
 		const verificationKeyValue = parsed.verificationKeys['did:key:z6MkVerification'];
 		assert(verificationKeyValue.startsWith('z'), 'Verification key should be multibase base58btc');
 		const decodedVerification = base58btc.decode(verificationKeyValue);
@@ -204,7 +204,7 @@ describe('saveRotationKeyToFile', () => {
 		const content = await readFile(outputFile, 'utf-8');
 		const parsed = JSON.parse(content);
 		assert.strictEqual(parsed.rotationKeys['did:key:zQ3shExisting'], '11223344');
-		// New key should be multibase encoded
+		// New key should be PEM encoded
 		const newKeyValue = parsed.rotationKeys['did:key:zQ3shNew'];
 		assert(newKeyValue.startsWith('z'), 'New key should be multibase encoded');
 	});
@@ -384,7 +384,7 @@ describe('saveVerificationKeyToFile', () => {
 		const content = await readFile(outputFile, 'utf-8');
 		const parsed = JSON.parse(content);
 		assert.strictEqual(parsed.verificationKeys['did:key:z6MkExisting'], '11223344');
-		// New key should be multibase encoded
+		// New key should be PEM encoded
 		const newKeyValue = parsed.verificationKeys['did:key:z6MkNew'];
 		assert(newKeyValue.startsWith('z'), 'New key should be multibase encoded');
 	});


### PR DESCRIPTION
This switches to storing private keys in PEM format while retaining support for reading multibase base58btc and raw hex.

This also adjusts the multibase handling so 64 byte verification keys generated by Sodium in FAIR Beacon are handled correctly.

Support for the raw hex format will be removed at a later date.