### PR TITLE
Replace all uses of 'new Client' with createPlcClient() wrapper

### DIFF
--- a/src/did.ts
+++ b/src/did.ts
@@ -73,7 +73,7 @@ export async function generateDID({
 /**
  * Creates a PLC directory client.
  */
-function createPlcClient(url = PLC_DIRECTORY_URL): Client {
+export function createPlcClient(url = PLC_DIRECTORY_URL): Client {
 	return new Client(url);
 }
 

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -1,6 +1,6 @@
 import { resolveTxt } from 'node:dns/promises';
 import { Client } from '@did-plc/lib';
-import { PLC_DIRECTORY_URL } from './did.js';
+import { PLC_DIRECTORY_URL, createPlcClient } from './did.js';
 
 const DOMAIN_REGEX = /^[a-z0-9][a-z0-9-]{0,62}(\.[a-z0-9][a-z0-9-]{0,62})+$/i;
 const DID_RECORD_REGEX = /^did="?([^"]+)"?$/;
@@ -109,7 +109,7 @@ export async function verifyDomainDid(domain: string, expectedDid: string): Prom
  * @throws {MultipleAliasesError} If more than one fair:// alias exists
  */
 export async function getFairAlias(did: string, plcUrl = PLC_DIRECTORY_URL): Promise<string> {
-	const client = new Client(plcUrl);
+	const client = createPlcClient(plcUrl);
 	const doc = await client.getDocument(did);
 	const aliases = (doc.alsoKnownAs || []).filter((url) => url.startsWith('fair://'));
 

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -1,5 +1,4 @@
 import { resolveTxt } from 'node:dns/promises';
-import { Client } from '@did-plc/lib';
 import { PLC_DIRECTORY_URL, createPlcClient } from './did.js';
 
 const DOMAIN_REGEX = /^[a-z0-9][a-z0-9-]{0,62}(\.[a-z0-9][a-z0-9-]{0,62})+$/i;

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -9,7 +9,7 @@ import { Client, DidDocument } from '@did-plc/lib';
 import { Ed25519Keypair } from './Ed25519Keypair.js';
 import { fetchOptions } from './utils.js';
 import { METADATA_CONTEXT, verifyArtifact } from './metadata.js';
-import { PLC_DIRECTORY_URL, FAIR_SERVICE_TYPE } from './did.js';
+import { PLC_DIRECTORY_URL, FAIR_SERVICE_TYPE, createPlcClient } from './did.js';
 import { validateDidLog, DidLogFetchError, DidLogValidationError } from './plc-log.js';
 import {
 	getFairAlias,
@@ -777,7 +777,7 @@ export async function verifyDid(options: VerifyDidOptions): Promise<DidVerificat
 	// 2. Fetch DID document
 	let didDocument: DidDocument;
 	try {
-		const client = new Client(plcUrl);
+		const client = createPlcClient(plcUrl);
 		didDocument = await client.getDocument(did);
 	} catch (err) {
 		result.valid = false;

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -5,7 +5,7 @@
  */
 
 import { createHash, timingSafeEqual } from 'node:crypto';
-import { Client, DidDocument } from '@did-plc/lib';
+import { DidDocument } from '@did-plc/lib';
 import { Ed25519Keypair } from './Ed25519Keypair.js';
 import { fetchOptions } from './utils.js';
 import { METADATA_CONTEXT, verifyArtifact } from './metadata.js';


### PR DESCRIPTION
This change ensures consistent PLC client creation throughout the codebase by:
- Exporting the createPlcClient() function from src/did.ts
- Replacing direct 'new Client()' instantiation in src/verify.ts and src/domain.ts
- Using the centralized wrapper function for better maintainability