### PR TITLE
Add command to check verification key validity

### DIFF
--- a/src/Ed25519Keypair.ts
+++ b/src/Ed25519Keypair.ts
@@ -8,6 +8,17 @@ import * as uint8arrays from 'uint8arrays';
 export const ED25519_PUBLIC_PREFIX = new Uint8Array([0xed, 0x01]);
 
 /**
+ * Multibase base58btc prefix for Ed25519 public keys (z6Mk).
+ * This is the base58btc encoding of ED25519_PUBLIC_PREFIX.
+ */
+export const ED25519_PUBLIC_MULTIBASE_PREFIX = 'z6Mk';
+
+/**
+ * Prefix for did:key URIs.
+ */
+export const DID_KEY_PREFIX = 'did:key:';
+
+/**
  * Multicodec prefix for Ed25519 private keys.
  */
 export const ED25519_PRIVATE_PREFIX = new Uint8Array([0x80, 0x26]);

--- a/src/cli/did-verification-key-check.ts
+++ b/src/cli/did-verification-key-check.ts
@@ -2,7 +2,7 @@
 
 import { parseArgs } from 'node:util';
 import { readFile } from 'node:fs/promises';
-import { getVerificationPublicKeyMultibase, VerificationKeyInputError } from '../keys.js';
+import { getVerificationPublicKeyMultibase, parsePublicKeyOnly, VerificationKeyInputError } from '../keys.js';
 import { validatePlcDid, DidValidationError } from '../did-validation.js';
 import { checkVerificationKey, MetadataFetchError } from '../verify.js';
 
@@ -34,8 +34,10 @@ Required:
   --did <did>          The DID to check (did:plc:...)
 
 Key input (one required):
-  --key <key>          Verification key (public: did:key:z6Mk... or z6Mk..., or private: PEM/multibase/hex)
-  --key-file <file>    Read verification key from file
+  --key <key>          Public key in did:key format (did:key:z6Mk...) or multibase format (z6Mk...).
+  --key-file <file>    Read verification key from file. Accepts a public key or a private keypair.
+                       Public key should be in did:key format (did:key:z6Mk...) or multibase format (z6Mk...).
+                       Private key can be in PEM, multibase, or hex format.
 
 Optional:
   --help               Show this help message
@@ -79,26 +81,24 @@ try {
 	throw err;
 }
 
-// Load the key input
-let keyInput: string;
-try {
-	if (values['key-file']) {
-		keyInput = await readFile(values['key-file'], 'utf-8');
-	} else {
-		keyInput = values.key!;
-	}
-} catch (err) {
-	console.error(`Error reading key file: ${(err as Error).message}`);
-	process.exit(2);
-}
-
 // Extract the public key multibase
 let publicKeyMultibase: string;
 try {
-	publicKeyMultibase = await getVerificationPublicKeyMultibase(keyInput);
+	if (values['key-file']) {
+		// --key-file accepts both public and private keys
+		const keyInput = await readFile(values['key-file'], 'utf-8');
+		publicKeyMultibase = await getVerificationPublicKeyMultibase(keyInput);
+	} else {
+		// --key only accepts public keys
+		publicKeyMultibase = await parsePublicKeyOnly(values.key!);
+	}
 } catch (err) {
 	if (err instanceof VerificationKeyInputError) {
 		console.error(`Error: ${err.message}`);
+		process.exit(2);
+	}
+	if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+		console.error(`Error reading key file: ${(err as Error).message}`);
 		process.exit(2);
 	}
 	throw err;

--- a/src/cli/did-verification-key-check.ts
+++ b/src/cli/did-verification-key-check.ts
@@ -128,6 +128,10 @@ try {
 	if (err instanceof SigningKeyError) {
 		console.error(`Error: ${err.message}`);
 		process.exit(2);
+	} else if (err instanceof Error) {
+		// Handle generic errors from key parsing (e.g., Ed25519Keypair.fromPublicKeyMultibase)
+		console.error(`Error: ${err.message}`);
+		process.exit(2);
 	}
 	throw err;
 }

--- a/src/cli/did-verification-key-check.ts
+++ b/src/cli/did-verification-key-check.ts
@@ -2,12 +2,9 @@
 
 import { parseArgs } from 'node:util';
 import { readFile } from 'node:fs/promises';
-import { importVerificationKeyPair } from '../keys.js';
-import { SigningKeyError, isMultibaseVerificationKey, isPKCS8PrivateKeyPEM, isHexPrivateKey, parseAsVerificationKey } from '../signing.js';
+import { getVerificationPublicKeyMultibase, VerificationKeyInputError } from '../keys.js';
 import { validatePlcDid, DidValidationError } from '../did-validation.js';
-import { extractVerificationKeys } from '../verify.js';
-import { PLC_DIRECTORY_URL, createPlcClient } from '../plc.js';
-import { Ed25519Keypair } from '../Ed25519Keypair.js';
+import { checkVerificationKey, MetadataFetchError } from '../verify.js';
 
 const { values } = parseArgs({
 	options: {
@@ -82,94 +79,63 @@ try {
 	throw err;
 }
 
-// Load the key
+// Load the key input
 let keyInput: string;
 try {
 	if (values['key-file']) {
-		keyInput = (await readFile(values['key-file'], 'utf-8')).trim();
+		keyInput = await readFile(values['key-file'], 'utf-8');
 	} else {
-		keyInput = values.key!.trim();
+		keyInput = values.key!;
 	}
 } catch (err) {
 	console.error(`Error reading key file: ${(err as Error).message}`);
 	process.exit(2);
 }
 
-// Determine if the key is a public key or private key and extract the public key multibase
+// Extract the public key multibase
 let publicKeyMultibase: string;
-
 try {
-	// Check if it's a did:key format (public key)
-	if (keyInput.startsWith('did:key:')) {
-		const multibase = keyInput.slice('did:key:'.length);
-		// Validate it by creating a keypair
-		await Ed25519Keypair.fromPublicKeyMultibase(multibase);
-		publicKeyMultibase = multibase;
-	}
-	// Check if it's a raw multibase public key (starts with z6Mk for Ed25519)
-	else if (keyInput.startsWith('z6Mk')) {
-		// Validate it by creating a keypair
-		await Ed25519Keypair.fromPublicKeyMultibase(keyInput);
-		publicKeyMultibase = keyInput;
-	}
-	// Check if it's a private key format
-	else if (isPKCS8PrivateKeyPEM(keyInput) || isMultibaseVerificationKey(keyInput) || isHexPrivateKey(keyInput)) {
-		// Import the private key and derive the public key
-		const privateKeyHex = parseAsVerificationKey(keyInput);
-		const { keypair } = await importVerificationKeyPair(privateKeyHex);
-		publicKeyMultibase = keypair.publicKeyStr();
-	} else {
-		throw new SigningKeyError(
-			'Unrecognized key format. Expected a public key (did:key:z6Mk... or z6Mk...) or private key (PEM, multibase, or hex)',
-		);
-	}
+	publicKeyMultibase = await getVerificationPublicKeyMultibase(keyInput);
 } catch (err) {
-	if (err instanceof SigningKeyError) {
-		console.error(`Error: ${err.message}`);
-		process.exit(2);
-	} else if (err instanceof Error) {
-		// Handle generic errors from key parsing (e.g., Ed25519Keypair.fromPublicKeyMultibase)
+	if (err instanceof VerificationKeyInputError) {
 		console.error(`Error: ${err.message}`);
 		process.exit(2);
 	}
 	throw err;
 }
 
-// Fetch the DID document
-console.log(`Fetching DID document for ${did}...`);
-const client = createPlcClient(PLC_DIRECTORY_URL);
-let didDocument;
+// Check if the key is valid for the DID
+console.log(`Checking verification key for ${did}...`);
+
+let result;
 try {
-	didDocument = await client.getDocument(did);
+	result = await checkVerificationKey(did, publicKeyMultibase);
 } catch (err) {
-	console.error(`Error: Failed to fetch DID document: ${(err as Error).message}`);
-	process.exit(2);
+	if (err instanceof MetadataFetchError) {
+		console.error(`Error: Failed to fetch DID document: ${err.message}`);
+		process.exit(2);
+	}
+	throw err;
 }
 
-// Extract verification keys from the DID document
-const verificationKeys = extractVerificationKeys(didDocument);
-
-if (verificationKeys.length === 0) {
+if (result.allKeys.length === 0) {
 	console.log(`\n❌ No verification keys found in DID document`);
 	console.log(`The DID ${did} has no verification keys.`);
 	process.exit(1);
 }
 
-// Check if the public key multibase is in the verification methods
-const matchingKey = verificationKeys.find((vk) => vk.publicKeyMultibase === publicKeyMultibase);
-
-if (matchingKey) {
+if (result.valid) {
 	console.log(`\n✓ Verification key is valid`);
-	console.log(`Key ID: ${matchingKey.id}`);
-	console.log(`Public key: ${publicKeyMultibase}`);
+	console.log(`Key ID: ${result.matchingKeyId}`);
+	console.log(`Public key: ${result.publicKeyMultibase}`);
 	console.log(`This key can be used to sign releases for ${did}`);
 	process.exit(0);
 } else {
 	console.log(`\n❌ Verification key is not valid`);
-	console.log(`Public key: ${publicKeyMultibase}`);
+	console.log(`Public key: ${result.publicKeyMultibase}`);
 	console.log(`This key is not present in the verification methods of ${did}`);
 	console.log(`\nValid keys for this DID:`);
-	for (const vk of verificationKeys) {
+	for (const vk of result.allKeys) {
 		console.log(`  ${vk.id}: ${vk.publicKeyMultibase}`);
 	}
 	process.exit(1);

--- a/src/cli/did-verification-key-check.ts
+++ b/src/cli/did-verification-key-check.ts
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+import { parseArgs } from 'node:util';
+import { readFile } from 'node:fs/promises';
+import crypto from 'node:crypto';
+import { importVerificationKeyPair } from '../keys.js';
+import { SigningKeyError, isMultibaseVerificationKey, isPKCS8PrivateKeyPEM, isHexPrivateKey } from '../signing.js';
+import { validatePlcDid, DidValidationError } from '../did-validation.js';
+import { extractVerificationKeys } from '../verify.js';
+import { PLC_DIRECTORY_URL, createPlcClient } from '../plc.js';
+import { Ed25519Keypair } from '../Ed25519Keypair.js';
+
+const { values } = parseArgs({
+	options: {
+		did: {
+			type: 'string',
+		},
+		key: {
+			type: 'string',
+		},
+		'key-file': {
+			type: 'string',
+		},
+		help: {
+			type: 'boolean',
+		},
+	},
+});
+
+if (values.help) {
+	console.log(`Usage: fair-tools did verification-key check [options]
+
+Check if a verification key is valid for signing.
+
+Valid verification keys are present in the verification methods property of the DID document.
+
+Required:
+  --did <did>          The DID to check (did:plc:...)
+
+Key input (one required):
+  --key <key>          Verification key (public: did:key:z6Mk... or z6Mk..., or private: PEM/multibase/hex)
+  --key-file <file>    Read verification key from file
+
+Optional:
+  --help               Show this help message
+
+Exit codes:
+  0  Key is valid (present in DID document)
+  1  Key is not valid (not found or DID has no verification keys)
+  2  Error occurred (invalid input, network error, etc.)`);
+	process.exit(0);
+}
+
+// Validate required options
+if (!values.did) {
+	console.error('Error: Missing required option: --did');
+	console.error('Run with --help for usage information.');
+	process.exit(2);
+}
+
+if (!values.key && !values['key-file']) {
+	console.error('Error: Must provide either --key or --key-file');
+	console.error('Run with --help for usage information.');
+	process.exit(2);
+}
+
+if (values.key && values['key-file']) {
+	console.error('Error: Cannot specify both --key and --key-file');
+	console.error('Run with --help for usage information.');
+	process.exit(2);
+}
+
+const did = values.did;
+
+// Validate DID format
+try {
+	validatePlcDid(did);
+} catch (err) {
+	if (err instanceof DidValidationError) {
+		console.error(`Error: ${err.message}`);
+		process.exit(2);
+	}
+	throw err;
+}
+
+// Load the key
+let keyInput: string;
+try {
+	if (values['key-file']) {
+		keyInput = (await readFile(values['key-file'], 'utf-8')).trim();
+	} else {
+		keyInput = values.key!.trim();
+	}
+} catch (err) {
+	console.error(`Error reading key file: ${(err as Error).message}`);
+	process.exit(2);
+}
+
+// Determine if the key is a public key or private key and extract the public key multibase
+let publicKeyMultibase: string;
+
+try {
+	// Check if it's a did:key format (public key)
+	if (keyInput.startsWith('did:key:')) {
+		const multibase = keyInput.slice('did:key:'.length);
+		// Validate it by creating a keypair
+		await Ed25519Keypair.fromPublicKeyMultibase(multibase);
+		publicKeyMultibase = multibase;
+	}
+	// Check if it's a raw multibase public key (starts with z6Mk for Ed25519)
+	else if (keyInput.startsWith('z6Mk')) {
+		// Validate it by creating a keypair
+		await Ed25519Keypair.fromPublicKeyMultibase(keyInput);
+		publicKeyMultibase = keyInput;
+	}
+	// Check if it's a private key format
+	else if (isPKCS8PrivateKeyPEM(keyInput) || isMultibaseVerificationKey(keyInput) || isHexPrivateKey(keyInput)) {
+		// Import the private key and derive the public key
+		const { privateKeyHex } = await loadVerificationKeyFromString(keyInput);
+		const { keypair } = await importVerificationKeyPair(privateKeyHex);
+		publicKeyMultibase = keypair.publicKeyStr();
+	} else {
+		throw new SigningKeyError(
+			'Unrecognized key format. Expected a public key (did:key:z6Mk... or z6Mk...) or private key (PEM, multibase, or hex)',
+		);
+	}
+} catch (err) {
+	if (err instanceof SigningKeyError) {
+		console.error(`Error: ${err.message}`);
+		process.exit(2);
+	}
+	throw err;
+}
+
+// Fetch the DID document
+console.log(`Fetching DID document for ${did}...`);
+const client = createPlcClient(PLC_DIRECTORY_URL);
+let didDocument;
+try {
+	didDocument = await client.getDocument(did);
+} catch (err) {
+	console.error(`Error: Failed to fetch DID document: ${(err as Error).message}`);
+	process.exit(2);
+}
+
+// Extract verification keys from the DID document
+const verificationKeys = extractVerificationKeys(didDocument);
+
+if (verificationKeys.length === 0) {
+	console.log(`\n❌ No verification keys found in DID document`);
+	console.log(`The DID ${did} has no verification keys.`);
+	process.exit(1);
+}
+
+// Check if the public key multibase is in the verification methods
+const matchingKey = verificationKeys.find((vk) => vk.publicKeyMultibase === publicKeyMultibase);
+
+if (matchingKey) {
+	console.log(`\n✓ Verification key is valid`);
+	console.log(`Key ID: ${matchingKey.id}`);
+	console.log(`Public key: ${publicKeyMultibase}`);
+	console.log(`This key can be used to sign releases for ${did}`);
+	process.exit(0);
+} else {
+	console.log(`\n❌ Verification key is not valid`);
+	console.log(`Public key: ${publicKeyMultibase}`);
+	console.log(`This key is not present in the verification methods of ${did}`);
+	console.log(`\nValid keys for this DID:`);
+	for (const vk of verificationKeys) {
+		console.log(`  ${vk.id}: ${vk.publicKeyMultibase}`);
+	}
+	process.exit(1);
+}
+
+/**
+ * Load a verification key from a string (PEM, multibase, or hex).
+ */
+async function loadVerificationKeyFromString(key: string): Promise<{ privateKeyHex: string }> {
+	const trimmed = key.trim();
+
+	if (isPKCS8PrivateKeyPEM(trimmed)) {
+		let keyObject: crypto.KeyObject;
+		try {
+			keyObject = crypto.createPrivateKey({
+				key: trimmed,
+				format: 'pem',
+			});
+		} catch {
+			throw new SigningKeyError('Invalid verification key. The PEM file could not be parsed.');
+		}
+
+		// Export as JWK to get the raw 'd' parameter (private key)
+		const jwk = keyObject.export({
+			format: 'jwk',
+		});
+		if (!jwk.d) {
+			throw new SigningKeyError('Invalid verification key. The PEM file is missing private key data.');
+		}
+
+		// JWK 'd' is base64url-encoded
+		const rawKey = Buffer.from(jwk.d, 'base64url');
+		if (rawKey.length !== 32) {
+			throw new SigningKeyError('Invalid verification key. The key has the wrong length.');
+		}
+
+		return { privateKeyHex: rawKey.toString('hex') };
+	}
+
+	if (isMultibaseVerificationKey(trimmed)) {
+		// Decode multibase verification key
+		const { base58btc } = await import('multiformats/bases/base58');
+		const { ED25519_PRIV_PREFIX } = await import('../signing.js');
+
+		let decoded: Uint8Array;
+		try {
+			decoded = base58btc.decode(trimmed);
+		} catch {
+			throw new SigningKeyError('Invalid key format. The key could not be decoded.');
+		}
+
+		if (decoded.length < 2) {
+			throw new SigningKeyError('Invalid key format. The key is too short.');
+		}
+
+		const prefixHex = Buffer.from(decoded.slice(0, 2)).toString('hex');
+		const ED25519_PRIV_PREFIX_HEX = Buffer.from(ED25519_PRIV_PREFIX).toString('hex');
+
+		if (prefixHex !== ED25519_PRIV_PREFIX_HEX) {
+			throw new SigningKeyError(`Unrecognized key type (prefix: ${prefixHex}). Expected a verification key.`);
+		}
+
+		const rawKey = decoded.slice(2);
+
+		// Sodium format: 64 bytes (32-byte seed + 32-byte public key)
+		if (rawKey.length === 64) {
+			return { privateKeyHex: Buffer.from(rawKey.slice(0, 32)).toString('hex') };
+		}
+
+		throw new SigningKeyError('Invalid key format. Expected a 64-byte Sodium-format Ed25519 key.');
+	}
+
+	if (isHexPrivateKey(trimmed)) {
+		return { privateKeyHex: trimmed.toLowerCase() };
+	}
+
+	throw new SigningKeyError('Unrecognized key format. Expected a PEM, multibase, or hex encoded verification key.');
+}

--- a/src/cli/did-verification-key-check.ts
+++ b/src/cli/did-verification-key-check.ts
@@ -2,9 +2,8 @@
 
 import { parseArgs } from 'node:util';
 import { readFile } from 'node:fs/promises';
-import crypto from 'node:crypto';
 import { importVerificationKeyPair } from '../keys.js';
-import { SigningKeyError, isMultibaseVerificationKey, isPKCS8PrivateKeyPEM, isHexPrivateKey } from '../signing.js';
+import { SigningKeyError, isMultibaseVerificationKey, isPKCS8PrivateKeyPEM, isHexPrivateKey, parseAsVerificationKey } from '../signing.js';
 import { validatePlcDid, DidValidationError } from '../did-validation.js';
 import { extractVerificationKeys } from '../verify.js';
 import { PLC_DIRECTORY_URL, createPlcClient } from '../plc.js';
@@ -116,7 +115,7 @@ try {
 	// Check if it's a private key format
 	else if (isPKCS8PrivateKeyPEM(keyInput) || isMultibaseVerificationKey(keyInput) || isHexPrivateKey(keyInput)) {
 		// Import the private key and derive the public key
-		const { privateKeyHex } = await loadVerificationKeyFromString(keyInput);
+		const privateKeyHex = parseAsVerificationKey(keyInput);
 		const { keypair } = await importVerificationKeyPair(privateKeyHex);
 		publicKeyMultibase = keypair.publicKeyStr();
 	} else {
@@ -170,78 +169,4 @@ if (matchingKey) {
 		console.log(`  ${vk.id}: ${vk.publicKeyMultibase}`);
 	}
 	process.exit(1);
-}
-
-/**
- * Load a verification key from a string (PEM, multibase, or hex).
- */
-async function loadVerificationKeyFromString(key: string): Promise<{ privateKeyHex: string }> {
-	const trimmed = key.trim();
-
-	if (isPKCS8PrivateKeyPEM(trimmed)) {
-		let keyObject: crypto.KeyObject;
-		try {
-			keyObject = crypto.createPrivateKey({
-				key: trimmed,
-				format: 'pem',
-			});
-		} catch {
-			throw new SigningKeyError('Invalid verification key. The PEM file could not be parsed.');
-		}
-
-		// Export as JWK to get the raw 'd' parameter (private key)
-		const jwk = keyObject.export({
-			format: 'jwk',
-		});
-		if (!jwk.d) {
-			throw new SigningKeyError('Invalid verification key. The PEM file is missing private key data.');
-		}
-
-		// JWK 'd' is base64url-encoded
-		const rawKey = Buffer.from(jwk.d, 'base64url');
-		if (rawKey.length !== 32) {
-			throw new SigningKeyError('Invalid verification key. The key has the wrong length.');
-		}
-
-		return { privateKeyHex: rawKey.toString('hex') };
-	}
-
-	if (isMultibaseVerificationKey(trimmed)) {
-		// Decode multibase verification key
-		const { base58btc } = await import('multiformats/bases/base58');
-		const { ED25519_PRIV_PREFIX } = await import('../signing.js');
-
-		let decoded: Uint8Array;
-		try {
-			decoded = base58btc.decode(trimmed);
-		} catch {
-			throw new SigningKeyError('Invalid key format. The key could not be decoded.');
-		}
-
-		if (decoded.length < 2) {
-			throw new SigningKeyError('Invalid key format. The key is too short.');
-		}
-
-		const prefixHex = Buffer.from(decoded.slice(0, 2)).toString('hex');
-		const ED25519_PRIV_PREFIX_HEX = Buffer.from(ED25519_PRIV_PREFIX).toString('hex');
-
-		if (prefixHex !== ED25519_PRIV_PREFIX_HEX) {
-			throw new SigningKeyError(`Unrecognized key type (prefix: ${prefixHex}). Expected a verification key.`);
-		}
-
-		const rawKey = decoded.slice(2);
-
-		// Sodium format: 64 bytes (32-byte seed + 32-byte public key)
-		if (rawKey.length === 64) {
-			return { privateKeyHex: Buffer.from(rawKey.slice(0, 32)).toString('hex') };
-		}
-
-		throw new SigningKeyError('Invalid key format. Expected a 64-byte Sodium-format Ed25519 key.');
-	}
-
-	if (isHexPrivateKey(trimmed)) {
-		return { privateKeyHex: trimmed.toLowerCase() };
-	}
-
-	throw new SigningKeyError('Unrecognized key format. Expected a PEM, multibase, or hex encoded verification key.');
 }

--- a/src/cli/fair-tools.ts
+++ b/src/cli/fair-tools.ts
@@ -47,6 +47,10 @@ const commands: { [key: string]: CommandTree } = {
 				description: 'Revoke a verification key',
 				load: () => import('./did-verification-key-revoke.js'),
 			},
+			check: {
+				description: 'Check if a verification key is valid',
+				load: () => import('./did-verification-key-check.js'),
+			},
 		},
 		'rotation-key': {
 			add: {

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -1,6 +1,6 @@
 import { Keypair, Secp256k1Keypair, verifySignature } from '@atproto/crypto';
 import { ed25519 } from '@noble/curves/ed25519';
-import { Ed25519Keypair } from './Ed25519Keypair.js';
+import { Ed25519Keypair, ED25519_PUBLIC_MULTIBASE_PREFIX, DID_KEY_PREFIX } from './Ed25519Keypair.js';
 
 export interface KeyPairBundle<T extends Keypair = Keypair> {
 	publicKey: string;
@@ -111,4 +111,61 @@ export async function verifyWithRotationKey(
 	publicKey: string,
 ): Promise<boolean> {
 	return verifySignature(publicKey, message, signature);
+}
+
+/**
+ * Error thrown when a verification key input is invalid.
+ */
+export class VerificationKeyInputError extends Error {}
+
+/**
+ * Extracts the public key multibase from a verification key input.
+ *
+ * Accepts:
+ * - Public key in did:key format (did:key:z6Mk...)
+ * - Public key multibase (z6Mk...)
+ * - Private key in PEM, multibase, or hex format (derives the public key)
+ *
+ * @param keyInput - The key input string
+ * @returns The public key multibase (z6Mk...)
+ * @throws {VerificationKeyInputError} If the key format is unrecognized or invalid
+ */
+export async function getVerificationPublicKeyMultibase(keyInput: string): Promise<string> {
+	const { isMultibaseVerificationKey, isPKCS8PrivateKeyPEM, isHexPrivateKey, parseAsVerificationKey } =
+		await import('./signing.js');
+
+	const trimmed = keyInput.trim();
+
+	if (trimmed.startsWith(DID_KEY_PREFIX)) {
+		const multibase = trimmed.slice(DID_KEY_PREFIX.length);
+		try {
+			await Ed25519Keypair.fromPublicKeyMultibase(multibase);
+		} catch (err) {
+			throw new VerificationKeyInputError(`Invalid did:key format: ${(err as Error).message}`);
+		}
+		return multibase;
+	}
+
+	if (trimmed.startsWith(ED25519_PUBLIC_MULTIBASE_PREFIX)) {
+		try {
+			await Ed25519Keypair.fromPublicKeyMultibase(trimmed);
+		} catch (err) {
+			throw new VerificationKeyInputError(`Invalid public key multibase: ${(err as Error).message}`);
+		}
+		return trimmed;
+	}
+
+	if (isPKCS8PrivateKeyPEM(trimmed) || isMultibaseVerificationKey(trimmed) || isHexPrivateKey(trimmed)) {
+		try {
+			const privateKeyHex = parseAsVerificationKey(trimmed);
+			const { keypair } = await importVerificationKeyPair(privateKeyHex);
+			return keypair.publicKeyStr();
+		} catch (err) {
+			throw new VerificationKeyInputError(`Invalid private key: ${(err as Error).message}`);
+		}
+	}
+
+	throw new VerificationKeyInputError(
+		'Unrecognized key format. Expected a public key (did:key:z6Mk...) or private key (PEM, multibase, or hex)',
+	);
 }

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -119,6 +119,33 @@ export async function verifyWithRotationKey(
 export class VerificationKeyInputError extends Error {}
 
 /**
+ * Parses a public key input and returns the multibase format.
+ *
+ * Only accepts public keys:
+ * - did:key format (did:key:z6Mk...)
+ * - Multibase format (z6Mk...)
+ *
+ * @param keyInput - The public key input string
+ * @returns The public key multibase (z6Mk...)
+ * @throws {VerificationKeyInputError} If the key format is unrecognized, invalid, or a private key
+ */
+export async function parsePublicKeyOnly(keyInput: string): Promise<string> {
+	const { isMultibaseVerificationKey, isPKCS8PrivateKeyPEM, isHexPrivateKey } = await import('./signing.js');
+
+	const trimmed = keyInput.trim();
+
+	// Check if it looks like a private key and reject with a specific error
+	if (isPKCS8PrivateKeyPEM(trimmed) || isMultibaseVerificationKey(trimmed) || isHexPrivateKey(trimmed)) {
+		throw new VerificationKeyInputError(
+			'Private key provided but only public keys are accepted. Use --key-file to provide a private key from a file.',
+		);
+	}
+
+	// Delegate to getVerificationPublicKeyMultibase for public key parsing
+	return getVerificationPublicKeyMultibase(trimmed);
+}
+
+/**
  * Extracts the public key multibase from a verification key input.
  *
  * Accepts:

--- a/src/signing.ts
+++ b/src/signing.ts
@@ -296,7 +296,7 @@ function parseAsRotationKey(content: string): string {
  * @returns {string} - The hex key
  * @throws {SigningKeyError} If the format is invalid or unrecognized
  */
-function parseAsVerificationKey(content: string): string {
+export function parseAsVerificationKey(content: string): string {
 	const trimmed = content.trim();
 
 	// Try PEM format first (PKCS#8 for Ed25519)

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -816,6 +816,45 @@ export async function verifyDid(options: VerifyDidOptions): Promise<DidVerificat
 	return result;
 }
 
+/**
+ * Result of checking if a verification key is valid for a DID.
+ */
+export interface CheckVerificationKeyResult {
+	valid: boolean;
+	publicKeyMultibase: string;
+	matchingKeyId: string | null;
+	allKeys: Array<{ id: string; publicKeyMultibase: string }>;
+}
+
+/**
+ * Checks if a verification key is valid for a DID.
+ *
+ * A verification key is valid if it's present in the DID document's verification methods.
+ *
+ * @param did - The DID to check (did:plc:...)
+ * @param publicKeyMultibase - The public key multibase to check (z6Mk...)
+ * @param plcUrl - Optional PLC directory URL
+ * @returns Result indicating if the key is valid and details about the match
+ * @throws {MetadataFetchError} If the DID document cannot be fetched
+ */
+export async function checkVerificationKey(
+	did: string,
+	publicKeyMultibase: string,
+	plcUrl = PLC_DIRECTORY_URL,
+): Promise<CheckVerificationKeyResult> {
+	const document = await fetchDidDocument(did, plcUrl);
+	const verificationKeys = extractVerificationKeys(document);
+
+	const matchingKey = verificationKeys.find((vk) => vk.publicKeyMultibase === publicKeyMultibase);
+
+	return {
+		valid: !!matchingKey,
+		publicKeyMultibase,
+		matchingKeyId: matchingKey?.id ?? null,
+		allKeys: verificationKeys,
+	};
+}
+
 // Re-export error types for consumers
 export { DidLogFetchError, DidLogValidationError } from './plc-log.js';
 export {

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -842,8 +842,7 @@ export async function checkVerificationKey(
 	publicKeyMultibase: string,
 	plcUrl = PLC_DIRECTORY_URL,
 ): Promise<CheckVerificationKeyResult> {
-	const document = await fetchDidDocument(did, plcUrl);
-	const verificationKeys = extractVerificationKeys(document);
+	const verificationKeys = await getVerificationKeys(did, plcUrl);
 
 	const matchingKey = verificationKeys.find((vk) => vk.publicKeyMultibase === publicKeyMultibase);
 

--- a/test/keys.test.ts
+++ b/test/keys.test.ts
@@ -8,6 +8,7 @@ import {
 	verifyWithVerificationKey,
 	verifyWithRotationKey,
 	getVerificationPublicKeyMultibase,
+	parsePublicKeyOnly,
 	VerificationKeyInputError,
 } from '../src/keys.js';
 import { encodeVerificationKey } from '../src/keyfile.js';
@@ -307,6 +308,101 @@ describe('getVerificationPublicKeyMultibase', () => {
 		const rotationKeys = await generateRotationKeyPair();
 
 		await assert.rejects(getVerificationPublicKeyMultibase(rotationKeys.publicKey), (err) => {
+			assert(err instanceof VerificationKeyInputError);
+			assert.match(err.message, /Invalid did:key format/);
+			return true;
+		});
+	});
+});
+
+describe('parsePublicKeyOnly', () => {
+	it('extracts multibase from did:key format', async () => {
+		const keys = await generateVerificationKeyPair();
+		const multibase = keys.keypair.publicKeyStr();
+
+		const result = await parsePublicKeyOnly(keys.publicKey);
+
+		assert.strictEqual(result, multibase);
+	});
+
+	it('returns raw multibase as-is when valid', async () => {
+		const keys = await generateVerificationKeyPair();
+		const multibase = keys.keypair.publicKeyStr();
+
+		const result = await parsePublicKeyOnly(multibase);
+
+		assert.strictEqual(result, multibase);
+	});
+
+	it('throws for hex private key', async () => {
+		const keys = await generateVerificationKeyPair();
+		const hexPrivateKey = Buffer.from(keys.privateKey).toString('hex');
+
+		await assert.rejects(parsePublicKeyOnly(hexPrivateKey), (err) => {
+			assert(err instanceof VerificationKeyInputError);
+			assert.match(err.message, /Private key provided but only public keys are accepted/);
+			return true;
+		});
+	});
+
+	it('throws for PEM private key', async () => {
+		const keys = await generateVerificationKeyPair();
+		const pemPrivateKey = encodeVerificationKey(keys.privateKey);
+
+		await assert.rejects(parsePublicKeyOnly(pemPrivateKey), (err) => {
+			assert(err instanceof VerificationKeyInputError);
+			assert.match(err.message, /Private key provided but only public keys are accepted/);
+			return true;
+		});
+	});
+
+	it('throws for multibase private key', async () => {
+		const keys = await generateVerificationKeyPair();
+
+		// Sodium format: 64 bytes (32-byte seed + 32-byte public key)
+		const ED25519_PRIV_PREFIX = new Uint8Array([0x80, 0x26]);
+		const sodiumKey = Buffer.concat([
+			Buffer.from(ED25519_PRIV_PREFIX),
+			Buffer.from(keys.privateKey),
+			Buffer.from(keys.keypair.publicKeyBytes()),
+		]);
+		const multibasePrivateKey = base58btc.encode(sodiumKey);
+
+		await assert.rejects(parsePublicKeyOnly(multibasePrivateKey), (err) => {
+			assert(err instanceof VerificationKeyInputError);
+			assert.match(err.message, /Private key provided but only public keys are accepted/);
+			return true;
+		});
+	});
+
+	it('throws for invalid did:key format', async () => {
+		await assert.rejects(parsePublicKeyOnly('did:key:invalid'), (err) => {
+			assert(err instanceof VerificationKeyInputError);
+			assert.match(err.message, /Invalid did:key format/);
+			return true;
+		});
+	});
+
+	it('throws for invalid multibase public key', async () => {
+		await assert.rejects(parsePublicKeyOnly('z6MkInvalidKey'), (err) => {
+			assert(err instanceof VerificationKeyInputError);
+			assert.match(err.message, /Invalid public key multibase/);
+			return true;
+		});
+	});
+
+	it('throws for unrecognized key format', async () => {
+		await assert.rejects(parsePublicKeyOnly('not-a-valid-key-format'), (err) => {
+			assert(err instanceof VerificationKeyInputError);
+			assert.match(err.message, /Unrecognized key format/);
+			return true;
+		});
+	});
+
+	it('throws for rotation key (wrong key type)', async () => {
+		const rotationKeys = await generateRotationKeyPair();
+
+		await assert.rejects(parsePublicKeyOnly(rotationKeys.publicKey), (err) => {
 			assert(err instanceof VerificationKeyInputError);
 			assert.match(err.message, /Invalid did:key format/);
 			return true;

--- a/test/keys.test.ts
+++ b/test/keys.test.ts
@@ -7,7 +7,11 @@ import {
 	importRotationKeyPair,
 	verifyWithVerificationKey,
 	verifyWithRotationKey,
+	getVerificationPublicKeyMultibase,
+	VerificationKeyInputError,
 } from '../src/keys.js';
+import { encodeVerificationKey } from '../src/keyfile.js';
+import { base58btc } from 'multiformats/bases/base58';
 
 describe('generate verification key pair', () => {
 	it('returns an object with publicKey, privateKey, and keypair', async () => {
@@ -206,5 +210,106 @@ describe('verify with rotation key', () => {
 		const isValid = await verifyWithRotationKey(wrongMessage, signature, keys.publicKey);
 
 		assert.strictEqual(isValid, false);
+	});
+});
+
+describe('getVerificationPublicKeyMultibase', () => {
+	it('extracts multibase from did:key format', async () => {
+		const keys = await generateVerificationKeyPair();
+		const multibase = keys.keypair.publicKeyStr();
+
+		const result = await getVerificationPublicKeyMultibase(keys.publicKey);
+
+		assert.strictEqual(result, multibase);
+	});
+
+	it('returns raw multibase as-is when valid', async () => {
+		const keys = await generateVerificationKeyPair();
+		const multibase = keys.keypair.publicKeyStr();
+
+		const result = await getVerificationPublicKeyMultibase(multibase);
+
+		assert.strictEqual(result, multibase);
+	});
+
+	it('derives public key from hex private key', async () => {
+		const keys = await generateVerificationKeyPair();
+		const hexPrivateKey = Buffer.from(keys.privateKey).toString('hex');
+		const expectedMultibase = keys.keypair.publicKeyStr();
+
+		const result = await getVerificationPublicKeyMultibase(hexPrivateKey);
+
+		assert.strictEqual(result, expectedMultibase);
+	});
+
+	it('derives public key from PEM private key', async () => {
+		const keys = await generateVerificationKeyPair();
+		const pemPrivateKey = encodeVerificationKey(keys.privateKey);
+		const expectedMultibase = keys.keypair.publicKeyStr();
+
+		const result = await getVerificationPublicKeyMultibase(pemPrivateKey);
+
+		assert.strictEqual(result, expectedMultibase);
+	});
+
+	it('derives public key from multibase private key', async () => {
+		const keys = await generateVerificationKeyPair();
+		const expectedMultibase = keys.keypair.publicKeyStr();
+
+		// Sodium format: 64 bytes (32-byte seed + 32-byte public key)
+		const ED25519_PRIV_PREFIX = new Uint8Array([0x80, 0x26]);
+		const sodiumKey = Buffer.concat([
+			Buffer.from(ED25519_PRIV_PREFIX),
+			Buffer.from(keys.privateKey),
+			Buffer.from(keys.keypair.publicKeyBytes()),
+		]);
+		const multibasePrivateKey = base58btc.encode(sodiumKey);
+
+		const result = await getVerificationPublicKeyMultibase(multibasePrivateKey);
+
+		assert.strictEqual(result, expectedMultibase);
+	});
+
+	it('trims whitespace from input', async () => {
+		const keys = await generateVerificationKeyPair();
+		const multibase = keys.keypair.publicKeyStr();
+
+		const result = await getVerificationPublicKeyMultibase('  ' + keys.publicKey + '\n');
+
+		assert.strictEqual(result, multibase);
+	});
+
+	it('throws for invalid did:key format', async () => {
+		await assert.rejects(getVerificationPublicKeyMultibase('did:key:invalid'), (err) => {
+			assert(err instanceof VerificationKeyInputError);
+			assert.match(err.message, /Invalid did:key format/);
+			return true;
+		});
+	});
+
+	it('throws for invalid multibase public key', async () => {
+		await assert.rejects(getVerificationPublicKeyMultibase('z6MkInvalidKey'), (err) => {
+			assert(err instanceof VerificationKeyInputError);
+			assert.match(err.message, /Invalid public key multibase/);
+			return true;
+		});
+	});
+
+	it('throws for unrecognized key format', async () => {
+		await assert.rejects(getVerificationPublicKeyMultibase('not-a-valid-key-format'), (err) => {
+			assert(err instanceof VerificationKeyInputError);
+			assert.match(err.message, /Unrecognized key format/);
+			return true;
+		});
+	});
+
+	it('throws for rotation key (wrong key type)', async () => {
+		const rotationKeys = await generateRotationKeyPair();
+
+		await assert.rejects(getVerificationPublicKeyMultibase(rotationKeys.publicKey), (err) => {
+			assert(err instanceof VerificationKeyInputError);
+			assert.match(err.message, /Invalid did:key format/);
+			return true;
+		});
 	});
 });


### PR DESCRIPTION
This pull request introduces a new CLI command for checking the validity of a verification key against a DID document. The main addition is a script that verifies whether a provided key (public or private) matches one of the verification methods registered for a given DID. The command provides clear exit codes and error handling for different scenarios.
